### PR TITLE
Padding bug

### DIFF
--- a/sites/all/modules/mediamosa/core/job/server/mediamosa_job_server.inc
+++ b/sites/all/modules/mediamosa/core/job/server/mediamosa_job_server.inc
@@ -773,7 +773,7 @@ class mediamosa_job_server {
     $parameter_string = '';
     $pairs = explode(';', $parameter_list);
     foreach ($pairs as $pair) {
-      $parameter_string .= str_replace(':' , ' ', $pair) . ' ';
+      $parameter_string .= preg_replace('/:/', ' ', $pair, 1) . ' ';
     }
 
     // Replace the one parameter placeholder.


### PR DESCRIPTION
Fixed code so that only one occurance of ':' gets replaced by ' '. That way the ':' in the padding parameters are kept and padding works correctly.
