### PR TITLE
Fix for Solr Simpletest

### DIFF
--- a/sites/all/modules/mediamosa/mediamosa.install
+++ b/sites/all/modules/mediamosa/mediamosa.install
@@ -3288,3 +3288,11 @@ function mediamosa_update_7132() {
     node_save($node);
   } 
 }
+
+/**
+ * Clean environment of SOLR for Simpletests (when SOLR module is on).
+ */
+function mediamosa_update_7133() {
+  // Call our cleanup hook for other stuff.
+  module_invoke_all('mediamosa_simpletest_clean_environment');
+}

--- a/sites/all/modules/mediamosa/modules/asset/mediamosa_asset.cql_appcoll.test
+++ b/sites/all/modules/mediamosa/modules/asset/mediamosa_asset.cql_appcoll.test
@@ -36,7 +36,7 @@ class MediaMosaAssetCQLAppCollTestCaseEga extends MediaMosaTestCaseEga {
   public static function getInfo() {
     return array(
       'name' => 'CQL - support app_id / coll_id seach in CQL',
-      'description' => 'Testing asset CQL related functions and rest calls for support app_id / coll_id seach in CQL.',
+      'description' => 'Testing asset CQL related functions and rest calls for support app_id / coll_id search in CQL.',
       'group' => MEDIAMOSA_TEST_GROUP_MEDIAMOSA_CORE_ASSET_CQL,
     );
   }

--- a/sites/all/modules/mediamosa_solr/mediamosa_solr.class.inc
+++ b/sites/all/modules/mediamosa_solr/mediamosa_solr.class.inc
@@ -721,7 +721,8 @@ class mediamosa_solr {
   /**
    * Delete documents of test data of the given app_ids.
    *
-   * @param array $app_ids
+   * @param $app_ids
+   *   The app_ids used for deleting the documents.
    */
   static public function delete_simpletest_documents(array $app_ids = array()) {
     try {
@@ -750,14 +751,13 @@ class mediamosa_solr {
 
           if ($found) {
             $found_total += $found;
-            self::deleteByQuery('app_id:' . $app_id);
+            self::deleteByQuery('app_id:' . $app_id);            
           }
-
         }
 
         // Commit.
         self::commit();
-
+        
         return $found_total;
       }
     }
@@ -1158,7 +1158,7 @@ class mediamosa_solr {
     }
 
     // Optimize when indicated.
-    if ($optimize) {
+    if ($optimize || mediamosa::in_simpletest_sandbox()) {
       // Optimize.
       $mediamosa_apache_solr_service->optimize();
     }

--- a/sites/all/modules/mediamosa_solr/tests/mediamosa_solr.acl.ega.test
+++ b/sites/all/modules/mediamosa_solr/tests/mediamosa_solr.acl.ega.test
@@ -100,12 +100,12 @@ class MediaMosaSolrAclEgaTestCaseEga extends MediaMosaAclEgaTestCaseEga {
       $app_ids[] = $this->a_app_3['app_id'];
     }
 
+    // Teardown first (else teardown will sync assets sometimes to SOLR).
+    parent::tearDown();
+
     // Remove it.
     if (!empty($app_ids)) {
       mediamosa_solr::delete_simpletest_documents($app_ids);
-      $this->pass(strtr('Removed metadata from solr for app ids @app_ids.', array('@app_ids' => implode(', ', $app_ids))));
     }
-
-    parent::tearDown();
   }
 }

--- a/sites/all/modules/mediamosa_solr/tests/mediamosa_solr.acl.granted.test
+++ b/sites/all/modules/mediamosa_solr/tests/mediamosa_solr.acl.granted.test
@@ -99,12 +99,12 @@ class MediaMosaSolrTestCaseAclGrantedJobTest extends MediaMosaTestCaseAclGranted
       $app_ids[] = $this->a_app_3['app_id'];
     }
 
+    // Teardown first (else teardown will sync assets sometimes to SOLR).
+    parent::tearDown();
+
     // Remove it.
     if (!empty($app_ids)) {
       mediamosa_solr::delete_simpletest_documents($app_ids);
-      $this->pass(strtr('Removed metadata from solr for app ids @app_ids.', array('@app_ids' => implode(', ', $app_ids))));
     }
-
-    parent::tearDown();
   }
 }

--- a/sites/all/modules/mediamosa_solr/tests/mediamosa_solr.acl.groups.master.slave.test
+++ b/sites/all/modules/mediamosa_solr/tests/mediamosa_solr.acl.groups.master.slave.test
@@ -99,12 +99,12 @@ class MediaMosaSolrAclGroupsMasterSlaveTestCaseEga extends MediaMosaAclGroupsMas
       $app_ids[] = $this->a_app_3['app_id'];
     }
 
+    // Teardown first (else teardown will sync assets sometimes to SOLR).
+    parent::tearDown();
+
     // Remove it.
     if (!empty($app_ids)) {
       mediamosa_solr::delete_simpletest_documents($app_ids);
-      $this->pass(strtr('Removed metadata from solr for app ids @app_ids.', array('@app_ids' => implode(', ', $app_ids))));
     }
-
-    parent::tearDown();
   }
 }

--- a/sites/all/modules/mediamosa_solr/tests/mediamosa_solr.acl.groups.test
+++ b/sites/all/modules/mediamosa_solr/tests/mediamosa_solr.acl.groups.test
@@ -99,12 +99,12 @@ class MediaMosaSolrAclGroupsTestCaseEga extends MediaMosaAclGroupsTestCaseEga {
       $app_ids[] = $this->a_app_3['app_id'];
     }
 
+    // Teardown first (else teardown will sync assets sometimes to SOLR).
+    parent::tearDown();
+
     // Remove it.
     if (!empty($app_ids)) {
       mediamosa_solr::delete_simpletest_documents($app_ids);
-      $this->pass(strtr('Removed metadata from solr for app ids @app_ids.', array('@app_ids' => implode(', ', $app_ids))));
     }
-
-    parent::tearDown();
   }
 }

--- a/sites/all/modules/mediamosa_solr/tests/mediamosa_solr.acl.master.slave.test
+++ b/sites/all/modules/mediamosa_solr/tests/mediamosa_solr.acl.master.slave.test
@@ -99,22 +99,12 @@ class MediaMosaSolrAclMasterSlaveTestCaseEga extends MediaMosaAclMasterSlaveTest
       $app_ids[] = $this->a_app_3['app_id'];
     }
 
-    // Build basic query.
-    foreach ($app_ids as $app_id) {
-      $solr_query[] = 'app_id:' . $app_id;
-    }
-
-    // Select all.
-    if (!empty($solr_query)) {
-      $solr_result = mediamosa_solr::search(implode(' OR ', $solr_query));
-    }
+    // Teardown first (else teardown will sync assets sometimes to SOLR).
+    parent::tearDown();
 
     // Remove it.
     if (!empty($app_ids)) {
       mediamosa_solr::delete_simpletest_documents($app_ids);
-      $this->pass(strtr('Removed metadata from solr for app ids @app_ids.', array('@app_ids' => implode(', ', $app_ids))));
     }
-
-    parent::tearDown();
   }
 }

--- a/sites/all/modules/mediamosa_solr/tests/mediamosa_solr.acl.mediafiles.test
+++ b/sites/all/modules/mediamosa_solr/tests/mediamosa_solr.acl.mediafiles.test
@@ -99,12 +99,12 @@ class MediaMosaSolrAclMediafileVisibleTestCaseEga extends MediaMosaAclMediafileV
       $app_ids[] = $this->a_app_3['app_id'];
     }
 
+    // Teardown first (else teardown will sync assets sometimes to SOLR).
+    parent::tearDown();
+
     // Remove it.
     if (!empty($app_ids)) {
       mediamosa_solr::delete_simpletest_documents($app_ids);
-      $this->pass(strtr('Removed metadata from solr for app ids @app_ids.', array('@app_ids' => implode(', ', $app_ids))));
     }
-
-    parent::tearDown();
   }
 }

--- a/sites/all/modules/mediamosa_solr/tests/mediamosa_solr.acl.slave.rights.test
+++ b/sites/all/modules/mediamosa_solr/tests/mediamosa_solr.acl.slave.rights.test
@@ -100,12 +100,12 @@ class MediaMosaSolrAclSlaveRightsTestCaseEga extends MediaMosaAclSlaveRightsTest
       $app_ids[] = $this->a_app_3['app_id'];
     }
 
+    // Teardown first (else teardown will sync assets sometimes to SOLR).
+    parent::tearDown();
+
     // Remove it.
     if (!empty($app_ids)) {
       mediamosa_solr::delete_simpletest_documents($app_ids);
-      $this->pass(strtr('Removed metadata from solr for app ids @app_ids.', array('@app_ids' => implode(', ', $app_ids))));
     }
-
-    parent::tearDown();
   }
 }

--- a/sites/all/modules/mediamosa_solr/tests/mediamosa_solr.acl.test
+++ b/sites/all/modules/mediamosa_solr/tests/mediamosa_solr.acl.test
@@ -100,12 +100,12 @@ class MediaMosaSolrAclTestCaseEga extends MediaMosaAclTestCaseEga {
       $app_ids[] = $this->a_app_3['app_id'];
     }
 
+    // Teardown first (else teardown will sync assets sometimes to SOLR).
+    parent::tearDown();
+
     // Remove it.
     if (!empty($app_ids)) {
       mediamosa_solr::delete_simpletest_documents($app_ids);
-      $this->pass(strtr('Removed metadata from solr for app ids @app_ids.', array('@app_ids' => implode(', ', $app_ids))));
     }
-
-    parent::tearDown();
   }
 }

--- a/sites/all/modules/mediamosa_solr/tests/mediamosa_solr.asset.collection.cql.test
+++ b/sites/all/modules/mediamosa_solr/tests/mediamosa_solr.asset.collection.cql.test
@@ -100,13 +100,13 @@ class MediaMosaSolrAssetCollectionCQLTestCaseEga extends MediaMosaAssetCollectio
       $app_ids[] = $this->a_app_3['app_id'];
     }
 
+    // Teardown first (else teardown will sync assets sometimes to SOLR).
+    parent::tearDown();
+
     // Remove it.
     if (!empty($app_ids)) {
       mediamosa_solr::delete_simpletest_documents($app_ids);
-      $this->pass(strtr('Removed metadata from solr for app ids @app_ids.', array('@app_ids' => implode(', ', $app_ids))));
     }
-
-    parent::tearDown();
   }
 
   /**

--- a/sites/all/modules/mediamosa_solr/tests/mediamosa_solr.asset.cql.acl.context.test
+++ b/sites/all/modules/mediamosa_solr/tests/mediamosa_solr.asset.cql.acl.context.test
@@ -100,12 +100,12 @@ class MediaMosaSolrAssetCQLAclContextTestCaseEga extends MediaMosaAssetCQLAclCon
       $app_ids[] = $this->a_app_3['app_id'];
     }
 
+    // Teardown first (else teardown will sync assets sometimes to SOLR).
+    parent::tearDown();
+
     // Remove it.
     if (!empty($app_ids)) {
       mediamosa_solr::delete_simpletest_documents($app_ids);
-      $this->pass(strtr('Removed metadata from solr for app ids @app_ids.', array('@app_ids' => implode(', ', $app_ids))));
     }
-
-    parent::tearDown();
   }
 }

--- a/sites/all/modules/mediamosa_solr/tests/mediamosa_solr.asset.cql.app.coll.test
+++ b/sites/all/modules/mediamosa_solr/tests/mediamosa_solr.asset.cql.app.coll.test
@@ -100,13 +100,13 @@ class MediaMosaSolrAssetCQLAppCollTestCaseEga extends MediaMosaAssetCQLAppCollTe
       $app_ids[] = $this->a_app_3['app_id'];
     }
 
+    // Teardown first (else teardown will sync assets sometimes to SOLR).
+    parent::tearDown();
+
     // Remove it.
     if (!empty($app_ids)) {
-    //  mediamosa_solr::delete_simpletest_documents($app_ids);
-    //  $this->pass(strtr('Removed metadata from solr for app ids @app_ids.', array('@app_ids' => implode(', ', $app_ids))));
+      mediamosa_solr::delete_simpletest_documents($app_ids);
     }
-
-    parent::tearDown();
   }
 
   /**

--- a/sites/all/modules/mediamosa_solr/tests/mediamosa_solr.asset.cql.isprivate.test
+++ b/sites/all/modules/mediamosa_solr/tests/mediamosa_solr.asset.cql.isprivate.test
@@ -100,13 +100,13 @@ class MediaMosaSolrAssetCQLIsPrivateTestCaseEga extends MediaMosaAssetCQLIsPriva
       $app_ids[] = $this->a_app_3['app_id'];
     }
 
+    // Teardown first (else teardown will sync assets sometimes to SOLR).
+    parent::tearDown();
+
     // Remove it.
     if (!empty($app_ids)) {
       mediamosa_solr::delete_simpletest_documents($app_ids);
-      $this->pass(strtr('Removed metadata from solr for app ids @app_ids.', array('@app_ids' => implode(', ', $app_ids))));
     }
-
-    parent::tearDown();
   }
 
   /**

--- a/sites/all/modules/mediamosa_solr/tests/mediamosa_solr.asset.cql.mediafile.duration.test
+++ b/sites/all/modules/mediamosa_solr/tests/mediamosa_solr.asset.cql.mediafile.duration.test
@@ -100,13 +100,13 @@ class MediaMosaSolrAssetCQLMediafileDurationTestCaseEga extends MediaMosaAssetCQ
       $app_ids[] = $this->a_app_3['app_id'];
     }
 
+    // Teardown first (else teardown will sync assets sometimes to SOLR).
+    parent::tearDown();
+
     // Remove it.
     if (!empty($app_ids)) {
       mediamosa_solr::delete_simpletest_documents($app_ids);
-      $this->pass(strtr('Removed metadata from solr for app ids @app_ids.', array('@app_ids' => implode(', ', $app_ids))));
     }
-
-    parent::tearDown();
   }
 
   /**

--- a/sites/all/modules/mediamosa_solr/tests/mediamosa_solr.asset.cql.test
+++ b/sites/all/modules/mediamosa_solr/tests/mediamosa_solr.asset.cql.test
@@ -100,13 +100,13 @@ class MediaMosaSolrAssetCQLTestCaseEga extends MediaMosaAssetCQLTestCaseEga {
       $app_ids[] = $this->a_app_3['app_id'];
     }
 
+    // Teardown first (else teardown will sync assets sometimes to SOLR).
+    parent::tearDown();
+
     // Remove it.
     if (!empty($app_ids)) {
       mediamosa_solr::delete_simpletest_documents($app_ids);
-      $this->pass(strtr('Removed metadata from solr for app ids @app_ids.', array('@app_ids' => implode(', ', $app_ids))));
     }
-
-    parent::tearDown();
   }
 
   /**

--- a/sites/all/modules/mediamosa_solr/tests/mediamosa_solr.asset.search.empty.test
+++ b/sites/all/modules/mediamosa_solr/tests/mediamosa_solr.asset.search.empty.test
@@ -100,12 +100,12 @@ class MediaMosaSolrAssetSearchEmptyTestCaseEga extends MediaMosaAssetSearchEmpty
       $app_ids[] = $this->a_app_3['app_id'];
     }
 
+    // Teardown first (else teardown will sync assets sometimes to SOLR).
+    parent::tearDown();
+
     // Remove it.
     if (!empty($app_ids)) {
       mediamosa_solr::delete_simpletest_documents($app_ids);
-      $this->pass(strtr('Removed metadata from solr for app ids @app_ids.', array('@app_ids' => implode(', ', $app_ids))));
     }
-
-    parent::tearDown();
   }
 }

--- a/sites/all/modules/mediamosa_solr/tests/mediamosa_solr.test
+++ b/sites/all/modules/mediamosa_solr/tests/mediamosa_solr.test
@@ -98,13 +98,13 @@ class MediaMosaSolrTestCaseEga extends MediaMosaTestCaseEgaJob {
       $app_ids[] = $this->a_app_3['app_id'];
     }
 
+    // Teardown first (else teardown will sync assets sometimes to SOLR).
+    parent::tearDown();
+
     // Remove it.
     if (!empty($app_ids)) {
       mediamosa_solr::delete_simpletest_documents($app_ids);
-      $this->pass(strtr('Removed metadata from solr for app ids @app_ids.', array('@app_ids' => implode(', ', $app_ids))));
     }
-
-    parent::tearDown();
   }
 
   // ------------------------------------------------------------------ Tests.


### PR DESCRIPTION
Solr Simpletests did not always clean up correctly; teardown ran sync code, which recreated the assets in some cases, after the clean up was run.
