### PR TITLE
Play restriction added to ACL layer

### DIFF
--- a/sites/all/modules/mediamosa/core/acl/mediamosa_acl.class.inc
+++ b/sites/all/modules/mediamosa/core/acl/mediamosa_acl.class.inc
@@ -1273,6 +1273,12 @@ class mediamosa_acl {
     // Get of this current user the acl_name/acl_group ids so we know his/her access.
     $a_acl_ids = mediamosa_acl::build_access($app_ids_tmp, $acl_user_id, $acl_group_ids, $acl_domain, $acl_realm, $slaves);
 
+    if (!$do_master_slave_only && $app_id_table_prefix == 'a' && ($acl_type == mediamosa_acl::ACL_TYPE_ASSET || $acl_type == mediamosa_acl::ACL_TYPE_MEDIAFILE)) {
+      $now = mediamosa_datetime::utc_current_timestamp_now();
+      $query[mediamosa_db_query::A_WHERE][mediamosa_db_query::WHERE_AND]['play_restriction'][] = strtr('(a.play_restriction_start IS NULL OR a.play_restriction_start < :now)', array(':now' => mediamosa_db::escape_string_quoted($now)));
+      $query[mediamosa_db_query::A_WHERE][mediamosa_db_query::WHERE_AND]['play_restriction'][] = strtr('(a.play_restriction_end IS NULL OR a.play_restriction_end > :now)', array(':now' => mediamosa_db::escape_string_quoted($now)));
+    }
+
     if (!is_null($acl_user_id) || (!is_null($acl_group_ids) && !empty($acl_group_ids)) || count($a_acl_ids) || count($slaves)) {
       switch ($acl_type) {
         case mediamosa_acl::ACL_TYPE_MEDIAFILE:

--- a/sites/all/modules/mediamosa/core/asset/mediafile/play_proxy/mediamosa_asset_mediafile_play_proxy.class.inc
+++ b/sites/all/modules/mediamosa/core/asset/mediafile/play_proxy/mediamosa_asset_mediafile_play_proxy.class.inc
@@ -764,14 +764,17 @@ class mediamosa_asset_mediafile_play_proxy {
   /**
    * Check if the time has been restricted.
    *
-   * @param string $time_restriction_start
-   * @param string $time_restriction_end
+   * @param $time_restriction_start
+   *   Start time in UTC of the time restriction period in datetime format
+   *   (optional).
+   * @param $time_restriction_end
+   *   End time in UTC of the time restriction period date.
    */
-  function check_time_restrictions($time_restriction_start, $time_restriction_end) {
-    if (time() < $time_restriction_start) {
+  function check_time_restrictions($time_restriction_start = '', $time_restriction_end = '') {
+    if ($time_restriction_start != '' && time() < $time_restriction_start) {
       throw new mediamosa_exception_error(mediamosa_error::ERRORCODE_TIME_RESTRICTION_START, array('@date' => date("Y-m-d H:i:s", $time_restriction_start), '@timestamp' => $time_restriction_start));
     }
-    if (time() > $time_restriction_end) {
+    if ($time_restriction_start != '' && time() > $time_restriction_end) {
       throw new mediamosa_exception_error(mediamosa_error::ERRORCODE_TIME_RESTRICTION_END, array('@date' => date("Y-m-d H:i:s", $time_restriction_end), '@timestamp' => $time_restriction_end));
     }
   }

--- a/sites/all/modules/mediamosa/core/asset/mediamosa_asset.class.inc
+++ b/sites/all/modules/mediamosa/core/asset/mediamosa_asset.class.inc
@@ -1181,6 +1181,14 @@ class mediamosa_asset {
       }
     }
 
+    // Check if the start and end dates are not switched (start > end).
+    if (!is_null($play_restriction_start) && !is_null($play_restriction_end)) {
+      if (mediamosa_datetime::date2unix($play_restriction_start) > mediamosa_datetime::date2unix($play_restriction_end)) {
+        // Swap start with end.
+        list($play_restriction_end, $play_restriction_start) = array($play_restriction_start, $play_restriction_end);
+      }
+    }
+
     $fields = array();
     if (!is_null($play_restriction_start)) {
       $fields[mediamosa_asset_db::PLAY_RESTRICTION_START] = $play_restriction_start == '' ? NULL : $play_restriction_start;

--- a/sites/all/modules/mediamosa/core/cql/mediamosa_core_cql.class.inc
+++ b/sites/all/modules/mediamosa/core/cql/mediamosa_core_cql.class.inc
@@ -1209,6 +1209,20 @@ class mediamosa_asset_cql_context extends mediamosa_core_cql_context {
                 MEDIAMOSA_CQL_CONTEXT_KEY_TABLE_ALIAS => 'a',
                 MEDIAMOSA_CQL_CONTEXT_KEY_TYPE => mediamosa_sdk::TYPE_DATETIME,
               ),
+              'play_restriction_start' => array(
+                MEDIAMOSA_CQL_CONTEXT_KEY_COLUMN => mediamosa_asset_db::PLAY_RESTRICTION_START,
+                MEDIAMOSA_CQL_CONTEXT_KEY_TABLE_FOR_SORT => mediamosa_asset_db::TABLE_NAME,
+                MEDIAMOSA_CQL_CONTEXT_KEY_TABLE_ALIAS => 'a',
+                MEDIAMOSA_CQL_CONTEXT_KEY_TYPE => mediamosa_sdk::TYPE_DATETIME,
+//                MEDIAMOSA_CQL_CONTEXT_KEY_NULL => TRUE,
+              ),
+              'play_restriction_end' => array(
+                MEDIAMOSA_CQL_CONTEXT_KEY_COLUMN => mediamosa_asset_db::PLAY_RESTRICTION_END,
+                MEDIAMOSA_CQL_CONTEXT_KEY_TABLE_FOR_SORT => mediamosa_asset_db::TABLE_NAME,
+                MEDIAMOSA_CQL_CONTEXT_KEY_TABLE_ALIAS => 'a',
+                MEDIAMOSA_CQL_CONTEXT_KEY_TYPE => mediamosa_sdk::TYPE_DATETIME,
+//                MEDIAMOSA_CQL_CONTEXT_KEY_NULL => TRUE,
+              ),
               'asset_created' => array(
                 MEDIAMOSA_CQL_CONTEXT_KEY_COLUMN => mediamosa_asset_db::CREATED,
                 MEDIAMOSA_CQL_CONTEXT_KEY_TABLE_FOR_SORT => mediamosa_asset_db::TABLE_NAME,

--- a/sites/all/modules/mediamosa/core/job/transcode/mediamosa_job_transcode.class.inc
+++ b/sites/all/modules/mediamosa/core/job/transcode/mediamosa_job_transcode.class.inc
@@ -75,27 +75,27 @@ class mediamosa_job_transcode {
 
     // Get the default transcode profile settings when not supplied.
     if (empty($profile_id) && $tool == '') {
-      $a_transcode_profile = mediamosa_transcode_profile::get_default($app_id);
-      if (!$a_transcode_profile) {
+      $transcode_profile = mediamosa_transcode_profile::get_default($app_id);
+      if (!$transcode_profile) {
         throw new mediamosa_exception_error(mediamosa_error::ERRORCODE_NO_DEFAULT_TRANSCODE_PROFILE);
       }
 
-      $profile_id = $a_transcode_profile[mediamosa_transcode_profile_db::ID];
-      $tool = $a_transcode_profile[mediamosa_transcode_profile_db::TOOL];
-      $file_extension = $a_transcode_profile[mediamosa_transcode_profile_db::FILE_EXTENSION];
-      $command = $a_transcode_profile[mediamosa_transcode_profile_db::COMMAND];
+      $profile_id = $transcode_profile[mediamosa_transcode_profile_db::ID];
+      $tool = $transcode_profile[mediamosa_transcode_profile_db::TOOL];
+      $file_extension = $transcode_profile[mediamosa_transcode_profile_db::FILE_EXTENSION];
+      $command = $transcode_profile[mediamosa_transcode_profile_db::COMMAND];
     }
     elseif (!empty($profile_id)) {
       // FIXME: should we add app_id here?
-      $a_transcode_profile = mediamosa_transcode_profile::get($profile_id);
+      $transcode_profile = mediamosa_transcode_profile::get($profile_id);
 
-      if (!$a_transcode_profile) {
+      if (!$transcode_profile) {
         throw new mediamosa_exception_error(mediamosa_error::ERRORCODE_NO_DEFAULT_TRANSCODE_PROFILE);
       }
 
-      $tool = $a_transcode_profile[mediamosa_transcode_profile_db::TOOL];
-      $file_extension = $a_transcode_profile[mediamosa_transcode_profile_db::FILE_EXTENSION];
-      $command = $a_transcode_profile[mediamosa_transcode_profile_db::COMMAND];
+      $tool = $transcode_profile[mediamosa_transcode_profile_db::TOOL];
+      $file_extension = $transcode_profile[mediamosa_transcode_profile_db::FILE_EXTENSION];
+      $command = $transcode_profile[mediamosa_transcode_profile_db::COMMAND];
     }
     else {
       $profile_id = NULL;

--- a/sites/all/modules/mediamosa/lib/mediamosa_datetime.class.inc
+++ b/sites/all/modules/mediamosa/lib/mediamosa_datetime.class.inc
@@ -176,7 +176,7 @@ class mediamosa_datetime {
    *
    * @return timestamp
    */
-  static public function utc_current_timestamp_add_hours($reset = FALSE, $hours) {
+  static public function utc_current_timestamp_add_hours($reset = FALSE, $hours = 0) {
     static $utc_timestamp_add_hours = array();
 
     if (isset($utc_timestamp_add_hours[$hours]) && !$reset) {

--- a/sites/all/modules/mediamosa/modules/acl/mediamosa_acl.granted.test
+++ b/sites/all/modules/mediamosa/modules/acl/mediamosa_acl.granted.test
@@ -107,7 +107,7 @@ class MediaMosaTestCaseAclGrantedJobTest extends MediaMosaTestCaseEgaJob {
     $mediafile_id_2 = $upload['mediafile_id'];
 
     // Must be the same.
-    $this->assertTrue($asset_id == $asset_id_2);
+    $this->assertTrue($asset_id == $asset_id_2, 'Assets are the same');
 
     // Get Mediafile.
     $mediafile_2 = $this->getMediafile($mediafile_id_2);

--- a/sites/all/modules/mediamosa/modules/acl/mediamosa_acl.info
+++ b/sites/all/modules/mediamosa/modules/acl/mediamosa_acl.info
@@ -1,5 +1,3 @@
-; $Id$
-
 name = "ACL"
 description = "The Access Control Layer module handles access to assets, media and other objects."
 package = "MediaMosa - Modules"
@@ -10,13 +8,14 @@ core = 7.x
 dependencies[] = mediamosa
 
 ; Used files.
-files[] = mediamosa_acl.rest.class.inc
-files[] = mediamosa_acl.test
-files[] = mediamosa_acl.masterslave.test
 files[] = mediamosa_acl.ega.test
-files[] = mediamosa_acl.owner.test
-files[] = mediamosa_acl.rights.test
-files[] = mediamosa_acl.group_masterslave.test
-files[] = mediamosa_acl.group.test
-files[] = mediamosa_acl.mediafiles.test
 files[] = mediamosa_acl.granted.test
+files[] = mediamosa_acl.group.test
+files[] = mediamosa_acl.group_masterslave.test
+files[] = mediamosa_acl.masterslave.test
+files[] = mediamosa_acl.mediafiles.test
+files[] = mediamosa_acl.owner.test
+files[] = mediamosa_acl.play_restriction.test
+files[] = mediamosa_acl.rest.class.inc
+files[] = mediamosa_acl.rights.test
+files[] = mediamosa_acl.test

--- a/sites/all/modules/mediamosa/modules/acl/mediamosa_acl.play_restriction.test
+++ b/sites/all/modules/mediamosa/modules/acl/mediamosa_acl.play_restriction.test
@@ -1,0 +1,211 @@
+<?php
+/**
+ * MediaMosa is Open Source Software to build a Full Featured, Webservice
+ * Oriented Media Management and Distribution platform (http://mediamosa.org)
+ *
+ * Copyright (C) 2011 SURFnet BV (http://www.surfnet.nl) and Kennisnet
+ * (http://www.kennisnet.nl)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, you can find it at:
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+ */
+
+/**
+  * @file
+  * Unittests for ACL play restriction.
+  */
+class MediaMosaAclPlayRestrictionTestCaseEga extends MediaMosaTestCaseEga {
+
+  // ------------------------------------------------------------------ Members.
+
+  // ------------------------------------------------------------------ Functions.
+  public static function getInfo() {
+    return array(
+      'name' => 'ACL - Play Restrictions',
+      'description' => 'Testing ACL asset and mediafile request from other application related functions and rest calls.',
+      'group' => MEDIAMOSA_TEST_GROUP_MEDIAMOSA_CORE_ACL,
+    );
+  }
+
+  // ------------------------------------------------------------------ Tests.
+  function testPlayRestriction() {
+    // Create upload file.
+    $upload_01 = $this->uploadTestFile();
+    $upload_02 = $this->uploadTestFile();
+    $upload_03 = $this->uploadTestFile();
+    $asset_id_01 = $upload_01['asset_id'];
+    $asset_id_02 = $upload_02['asset_id'];
+    $asset_id_03 = $upload_03['asset_id'];
+
+    // None are restricted, so all should return.
+    $this->cql_do_search_test_assets('', array($asset_id_01 => TRUE, $asset_id_02 => TRUE, $asset_id_03 => TRUE), array(), FALSE, FALSE, FALSE, FALSE, TRUE);
+    $this->cql_do_search_test_assets('', array($asset_id_01 => TRUE, $asset_id_02 => TRUE, $asset_id_03 => TRUE));
+
+    // With ACL rule, none are restricted, so all should return.
+    $this->cql_do_search_test_assets('', array($asset_id_01 => TRUE, $asset_id_02 => TRUE, $asset_id_03 => TRUE), array(), self::SIMPLETEST_USER_ID, FALSE, FALSE, FALSE, TRUE);
+    $this->cql_do_search_test_assets('', array($asset_id_01 => TRUE, $asset_id_02 => TRUE, $asset_id_03 => TRUE), array(), self::SIMPLETEST_USER_ID);
+
+    // Restrict mediafile 2, but between past and future.
+    $play_restriction_start = date('Y-m-d H:i:s', strtotime('-1 week'));
+    $play_restriction_end = date('Y-m-d H:i:s', strtotime('+1 week'));
+    $this->updateAsset($asset_id_02, array(mediamosa_rest_call_asset_update::PLAY_RESTRICTION_START => $play_restriction_start, mediamosa_rest_call_asset_update::PLAY_RESTRICTION_END => $play_restriction_end));
+    $this->pass(t('Setting for asset @asset_id play restriction start at @start and end at @end', array('@asset_id' => $asset_id_02, '@start' => $play_restriction_start, '@end' => $play_restriction_end)));
+
+    // Still all should return.
+    $this->cql_do_search_test_assets('', array($asset_id_01 => TRUE, $asset_id_02 => TRUE, $asset_id_03 => TRUE), array(), FALSE, FALSE, FALSE, FALSE, TRUE);
+    $this->cql_do_search_test_assets('', array($asset_id_01 => TRUE, $asset_id_02 => TRUE, $asset_id_03 => TRUE));
+
+    // With ACL rule, still all should return.
+    $this->cql_do_search_test_assets('', array($asset_id_01 => TRUE, $asset_id_02 => TRUE, $asset_id_03 => TRUE), array(), self::SIMPLETEST_USER_ID, FALSE, FALSE, FALSE, TRUE);
+    $this->cql_do_search_test_assets('', array($asset_id_01 => TRUE, $asset_id_02 => TRUE, $asset_id_03 => TRUE), array(), self::SIMPLETEST_USER_ID);
+
+    // Restrict mediafile 1, but in the past.
+    $play_restriction_start = date('Y-m-d H:i:s', strtotime('-1 week'));
+    $play_restriction_end = date('Y-m-d H:i:s', strtotime('-1 day'));
+    $this->updateAsset($asset_id_01, array(mediamosa_rest_call_asset_update::PLAY_RESTRICTION_START => $play_restriction_start, mediamosa_rest_call_asset_update::PLAY_RESTRICTION_END => $play_restriction_end));
+    $this->pass(t('Setting for asset @asset_id play restriction start at @start and end at @end', array('@asset_id' => $asset_id_01, '@start' => $play_restriction_start, '@end' => $play_restriction_end)));
+
+    // Asset 01 should not be granted.
+    $this->cql_do_search_test_assets('', array($asset_id_01 => FALSE, $asset_id_02 => TRUE, $asset_id_03 => TRUE), array(), FALSE, FALSE, FALSE, FALSE, TRUE);
+    $this->cql_do_search_test_assets('', array($asset_id_02 => TRUE, $asset_id_03 => TRUE));
+
+    // With ACL rule, asset 01 should not be granted.
+    $this->cql_do_search_test_assets('', array($asset_id_01 => FALSE, $asset_id_02 => TRUE, $asset_id_03 => TRUE), array(), self::SIMPLETEST_USER_ID, FALSE, FALSE, FALSE, TRUE);
+    $this->cql_do_search_test_assets('', array($asset_id_02 => TRUE, $asset_id_03 => TRUE), array(), self::SIMPLETEST_USER_ID);
+
+    // Restrict mediafile 3, but in the future.
+    $play_restriction_start = date('Y-m-d H:i:s', strtotime('+1 day'));
+    $play_restriction_end = date('Y-m-d H:i:s', strtotime('+1 week'));
+    $this->updateAsset($asset_id_03, array(mediamosa_rest_call_asset_update::PLAY_RESTRICTION_START => $play_restriction_start, mediamosa_rest_call_asset_update::PLAY_RESTRICTION_END => $play_restriction_end));
+    $this->pass(t('Setting for asset @asset_id play restriction start at @start and end at @end', array('@asset_id' => $asset_id_03, '@start' => $play_restriction_start, '@end' => $play_restriction_end)));
+
+    // Asset 01,03 should not be granted.
+    $this->cql_do_search_test_assets('', array($asset_id_01 => FALSE, $asset_id_02 => TRUE, $asset_id_03 => FALSE), array(), FALSE, FALSE, FALSE, FALSE, TRUE);
+    $this->cql_do_search_test_assets('', array($asset_id_02 => TRUE));
+
+    // With ACL rule, asset 01,03 should not be granted.
+    $this->cql_do_search_test_assets('', array($asset_id_01 => FALSE, $asset_id_02 => TRUE, $asset_id_03 => FALSE), array(), self::SIMPLETEST_USER_ID, FALSE, FALSE, FALSE, TRUE);
+    $this->cql_do_search_test_assets('', array($asset_id_02 => TRUE), array(), self::SIMPLETEST_USER_ID);
+
+    // Restrict mediafile 2, but in the past and future.
+    $play_restriction_start = date('Y-m-d H:i:s', strtotime('-1 week'));
+    $play_restriction_end = date('Y-m-d H:i:s', strtotime('+1 week'));
+    $this->updateAsset($asset_id_02, array(mediamosa_rest_call_asset_update::PLAY_RESTRICTION_START => $play_restriction_start, mediamosa_rest_call_asset_update::PLAY_RESTRICTION_END => $play_restriction_end));
+    $this->pass(t('Setting for asset @asset_id play restriction start at @start and end at @end', array('@asset_id' => $asset_id_02, '@start' => $play_restriction_start, '@end' => $play_restriction_end)));
+
+    // Asset 01,03 should not be granted.
+    $this->cql_do_search_test_assets('', array($asset_id_01 => FALSE, $asset_id_02 => TRUE, $asset_id_03 => FALSE), array(), FALSE, FALSE, FALSE, FALSE, TRUE);
+    $this->cql_do_search_test_assets('', array($asset_id_02 => TRUE));
+
+    // With ACL rule, asset 01,03 should not be granted.
+    $this->cql_do_search_test_assets('', array($asset_id_01 => FALSE, $asset_id_02 => TRUE, $asset_id_03 => FALSE), array(), self::SIMPLETEST_USER_ID, FALSE, FALSE, FALSE, TRUE);
+    $this->cql_do_search_test_assets('', array($asset_id_02 => TRUE), array(), self::SIMPLETEST_USER_ID);
+
+    // Reverse the date, let MediaMosa flip it.
+    // Restrict mediafile 3, but in the future.
+    $play_restriction_end = date('Y-m-d H:i:s', strtotime('+1 day'));
+    $play_restriction_start = date('Y-m-d H:i:s', strtotime('+1 week'));
+    $this->updateAsset($asset_id_03, array(mediamosa_rest_call_asset_update::PLAY_RESTRICTION_START => $play_restriction_start, mediamosa_rest_call_asset_update::PLAY_RESTRICTION_END => $play_restriction_end));
+    $this->pass(t('Setting for asset @asset_id play restriction start at @start and end at @end', array('@asset_id' => $asset_id_03, '@start' => $play_restriction_start, '@end' => $play_restriction_end)));
+
+    // Asset 01,03 should not be granted.
+    $this->cql_do_search_test_assets('', array($asset_id_01 => FALSE, $asset_id_02 => TRUE, $asset_id_03 => FALSE), array(), FALSE, FALSE, FALSE, FALSE, TRUE);
+    $this->cql_do_search_test_assets('', array($asset_id_02 => TRUE));
+
+    // With ACL rule, asset 01,03 should not be granted.
+    $this->cql_do_search_test_assets('', array($asset_id_01 => FALSE, $asset_id_02 => TRUE, $asset_id_03 => FALSE), array(), self::SIMPLETEST_USER_ID, FALSE, FALSE, FALSE, TRUE);
+    $this->cql_do_search_test_assets('', array($asset_id_02 => TRUE), array(), self::SIMPLETEST_USER_ID);
+
+    // Remove the date for asset 3.
+    $play_restriction_end = '';
+    $play_restriction_start = '';
+    $this->updateAsset($asset_id_03, array(mediamosa_rest_call_asset_update::PLAY_RESTRICTION_START => $play_restriction_start, mediamosa_rest_call_asset_update::PLAY_RESTRICTION_END => $play_restriction_end));
+    $this->pass(t('Setting for asset @asset_id play restriction start at @start and end at @end', array('@asset_id' => $asset_id_03, '@start' => $play_restriction_start, '@end' => $play_restriction_end)));
+
+    // Asset 01,03 should not be granted.
+    $this->cql_do_search_test_assets('', array($asset_id_01 => FALSE, $asset_id_02 => TRUE, $asset_id_03 => TRUE), array(), FALSE, FALSE, FALSE, FALSE, TRUE);
+    $this->cql_do_search_test_assets('', array($asset_id_02 => TRUE, $asset_id_03 => TRUE));
+
+    // With ACL rule, asset 01,03 should not be granted.
+    $this->cql_do_search_test_assets('', array($asset_id_01 => FALSE, $asset_id_02 => TRUE, $asset_id_03 => TRUE), array(), self::SIMPLETEST_USER_ID, FALSE, FALSE, FALSE, TRUE);
+    $this->cql_do_search_test_assets('', array($asset_id_02 => TRUE, $asset_id_03 => TRUE), array(), self::SIMPLETEST_USER_ID);
+
+
+    // -------------------------------------------------------------------------
+    // Test use case for;
+    // Show me all available media (inside the start and end date)
+    // Show me all expired media (outside the start and end date)
+
+
+    // Remove restrictions 1, 2 & 3.
+    $play_restriction_end = '';
+    $play_restriction_start = '';
+    $this->updateAsset($asset_id_01, array(mediamosa_rest_call_asset_update::PLAY_RESTRICTION_START => $play_restriction_start, mediamosa_rest_call_asset_update::PLAY_RESTRICTION_END => $play_restriction_end));
+    $this->pass(t('Setting for asset @asset_id play restriction start at @start and end at @end', array('@asset_id' => $asset_id_01, '@start' => $play_restriction_start, '@end' => $play_restriction_end)));
+    $this->updateAsset($asset_id_02, array(mediamosa_rest_call_asset_update::PLAY_RESTRICTION_START => $play_restriction_start, mediamosa_rest_call_asset_update::PLAY_RESTRICTION_END => $play_restriction_end));
+    $this->pass(t('Setting for asset @asset_id play restriction start at @start and end at @end', array('@asset_id' => $asset_id_02, '@start' => $play_restriction_start, '@end' => $play_restriction_end)));
+
+    // Should return all.
+    $this->cql_do_search_test_assets('', array($asset_id_01 => TRUE, $asset_id_02 => TRUE, $asset_id_03 => TRUE), array(), FALSE, FALSE, FALSE, FALSE, TRUE);
+
+    $weekago = date('Y-m-d\TH:i:s\Z', strtotime('-1 week'));
+    $weekfuture = date('Y-m-d\TH:i:s\Z', strtotime('+1 week'));
+
+    $play_restriction_start = $weekago;
+    $play_restriction_end = $weekfuture;
+    $this->updateAsset($asset_id_01, array(mediamosa_rest_call_asset_update::PLAY_RESTRICTION_START => $play_restriction_start, mediamosa_rest_call_asset_update::PLAY_RESTRICTION_END => $play_restriction_end));
+    $this->pass(t('Setting for asset @asset_id play restriction start at @start and end at @end', array('@asset_id' => $asset_id_01, '@start' => $play_restriction_start, '@end' => $play_restriction_end)));
+
+    $play_restriction_start = $weekago;
+    $play_restriction_end = date('Y-m-d H:i:s', strtotime('+1 day'));
+    $this->updateAsset($asset_id_02, array(mediamosa_rest_call_asset_update::PLAY_RESTRICTION_START => $play_restriction_start, mediamosa_rest_call_asset_update::PLAY_RESTRICTION_END => $play_restriction_end));
+    $this->pass(t('Setting for asset @asset_id play restriction start at @start and end at @end', array('@asset_id' => $asset_id_02, '@start' => $play_restriction_start, '@end' => $play_restriction_end)));
+
+    $play_restriction_start = date('Y-m-d H:i:s', strtotime('-1 day'));
+    $play_restriction_end = $weekfuture;
+    $this->updateAsset($asset_id_03, array(mediamosa_rest_call_asset_update::PLAY_RESTRICTION_START => $play_restriction_start, mediamosa_rest_call_asset_update::PLAY_RESTRICTION_END => $play_restriction_end));
+    $this->pass(t('Setting for asset @asset_id play restriction start at @start and end at @end', array('@asset_id' => $asset_id_03, '@start' => $play_restriction_start, '@end' => $play_restriction_end)));
+
+    // Should still return all.
+    $this->cql_do_search_test_assets('', array($asset_id_01 => TRUE, $asset_id_02 => TRUE, $asset_id_03 => TRUE), array(), FALSE, FALSE, FALSE, FALSE, TRUE);
+
+    $twodays_ago = date('Y-m-d\TH:i:s\Z', strtotime('-2 day'));
+    $twodays_future = date('Y-m-d\TH:i:s\Z', strtotime('+2 day'));
+
+    // Only 1 & 2.
+    $this->cql_do_search_test_assets(strtr('play_restriction_start < :twodaysago' , array(':twodaysago' => $twodays_ago)), array($asset_id_01 => TRUE, $asset_id_02 => TRUE), array(), FALSE, FALSE, FALSE, FALSE, TRUE);
+
+    // Only 1 & 3.
+    $this->cql_do_search_test_assets(strtr('play_restriction_end > :twodaysfuture' , array(':twodaysfuture' => $twodays_future)), array($asset_id_01 => TRUE, $asset_id_03 => TRUE), array(), FALSE, FALSE, FALSE, FALSE, TRUE);
+
+    $now = mediamosa_datetime::utc_current_timestamp_now();
+    $now = drupal_substr($now, 0, 10) . 'T' . drupal_substr($now, 11, 8) . 'Z';
+
+    // All of them.
+    $this->cql_do_search_test_assets(strtr('play_restriction_start < :now AND play_restriction_end > :now' , array(':now' => $now)), array($asset_id_01 => TRUE, $asset_id_02 => TRUE, $asset_id_03 => TRUE), array(), FALSE, FALSE, FALSE, FALSE, TRUE);
+
+    // None of them.
+    $this->cql_do_search_test_assets(strtr('play_restriction_start > :now OR play_restriction_end < :now' , array(':now' => $now)), array(), array(), FALSE, FALSE, FALSE, FALSE, TRUE);
+
+    // Expire asset 3.
+    $play_restriction_start = $weekago;
+    $play_restriction_end = $twodays_ago;
+    $this->updateAsset($asset_id_03, array(mediamosa_rest_call_asset_update::PLAY_RESTRICTION_START => $play_restriction_start, mediamosa_rest_call_asset_update::PLAY_RESTRICTION_END => $play_restriction_end));
+    $this->pass(t('Setting for asset @asset_id play restriction start at @start and end at @end', array('@asset_id' => $asset_id_03, '@start' => $play_restriction_start, '@end' => $play_restriction_end)));
+
+    // All of them, except asset 3.
+    $this->cql_do_search_test_assets(strtr('play_restriction_start < :now AND play_restriction_end > :now' , array(':now' => $now)), array($asset_id_01 => TRUE, $asset_id_02 => TRUE), array(), FALSE, FALSE, FALSE, FALSE, TRUE);
+
+    // Only asset 3.
+    $this->cql_do_search_test_assets(strtr('play_restriction_start > :now OR play_restriction_end < :now' , array(':now' => $now)), array($asset_id_03 => FALSE), array(), FALSE, FALSE, FALSE, FALSE, TRUE);
+  }
+}

--- a/sites/all/modules/mediamosa/modules/asset/mediafile/play_proxy/mediamosa_asset_mediafile_play_proxy.acl.test
+++ b/sites/all/modules/mediamosa/modules/asset/mediafile/play_proxy/mediamosa_asset_mediafile_play_proxy.acl.test
@@ -107,15 +107,12 @@ class MediaMosaAssetMediafilePlayProxyAclTestCaseEga extends MediaMosaTestCaseEg
     $end_time = time() - (24*60*60); // One day in the past.
     try {
       $result = mediamosa_asset_mediafile_play_proxy::check_time_restrictions($start_time, $end_time);
-      $this->assertTrue(
-        FALSE,
-        t("The check_time_restrictions() accepted the wrong value.")
-      );
+      $this->fail(t('The check_time_restrictions() accepted the wrong value.'));
     }
     catch (Exception $e) {
       $this->assertTrue(
         $e->getCode() == mediamosa_error::ERRORCODE_TIME_RESTRICTION_END,
-        t("The check_time_restrictions() bounced back the ERRORCODE_TIME_RESTRICTION_END error.")
+        t('The check_time_restrictions() bounced back the ERRORCODE_TIME_RESTRICTION_END error.')
       );
     }
 
@@ -158,15 +155,12 @@ class MediaMosaAssetMediafilePlayProxyAclTestCaseEga extends MediaMosaTestCaseEg
     $end_time = time() + (7*24*60*60); // One week in the future.
     try {
       $result = mediamosa_asset_mediafile_play_proxy::check_time_restrictions($start_time, $end_time);
-      $this->assertTrue(
-        FALSE,
-        t("The check_time_restrictions() accepted the wrong value.")
-      );
+      $this->fail(t('The check_time_restrictions() accepted the wrong value.'));
     }
     catch (Exception $e) {
       $this->assertTrue(
         $e->getCode() == mediamosa_error::ERRORCODE_TIME_RESTRICTION_START,
-        t("The check_time_restrictions() bounced back the ERRORCODE_TIME_RESTRICTION_START error.")
+        t('The check_time_restrictions() bounced back the ERRORCODE_TIME_RESTRICTION_START error.')
       );
     }
 
@@ -211,16 +205,10 @@ class MediaMosaAssetMediafilePlayProxyAclTestCaseEga extends MediaMosaTestCaseEg
     $end_time = time() + (24*60*60); // One day in the future.
     try {
       $result = mediamosa_asset_mediafile_play_proxy::check_time_restrictions($start_time, $end_time);
-      $this->assertTrue(
-        TRUE,
-        t("The check_time_restrictions() accepted the good values.")
-      );
+      $this->pass(t('The check_time_restrictions() accepted the good values.'));
     }
     catch (Exception $e) {
-      $this->assertTrue(
-        FALSE,
-        t("The check_time_restrictions() doesn't accepted the good values.")
-      );
+      $this->fail(t("The check_time_restrictions() doesn't accepted the good values."));
     }
 
     //

--- a/sites/all/modules/mediamosa/modules/asset/mediafile/play_proxy/mediamosa_asset_mediafile_play_proxy.rest.class.inc
+++ b/sites/all/modules/mediamosa/modules/asset/mediafile/play_proxy/mediamosa_asset_mediafile_play_proxy.rest.class.inc
@@ -272,7 +272,7 @@ class mediamosa_rest_call_asset_mediafile_play extends mediamosa_rest_call {
 
     if ($mediafile_id) {
       // Check play restrictions
-      if (isset($asset['play_restriction_start']) && isset($asset['play_restriction_end'])) {
+      if ($asset['play_restriction_start'] != '' || $asset['play_restriction_end'] != '') {
         $result = mediamosa_asset_mediafile_play_proxy::check_time_restrictions(
           strtotime($asset['play_restriction_start']),
           strtotime($asset['play_restriction_end'])

--- a/sites/all/modules/mediamosa/modules/asset/mediafile/play_proxy/mediamosa_asset_mediafile_play_proxy.ticket_mechanisme.test
+++ b/sites/all/modules/mediamosa/modules/asset/mediafile/play_proxy/mediamosa_asset_mediafile_play_proxy.ticket_mechanisme.test
@@ -57,8 +57,8 @@ class MediaMosaAssetMediafilePlayProxyTicketMechanismeTestCaseEga extends MediaM
     // Now transcode both.
 
     // Create transcode job.
-    $job_id_1 = $this->createMediafileTranscode($mediafile_id_1, array('profile_id' => 1));
-    $job_id_2 = $this->createMediafileTranscode($mediafile_id_2, array('profile_id' => 1));
+    $job_id_1 = $this->createMediafileTranscode($mediafile_id_1);
+    $job_id_2 = $this->createMediafileTranscode($mediafile_id_2);
 
     // Parse the queue.
     $this->doQueueCycleAll();
@@ -66,6 +66,9 @@ class MediaMosaAssetMediafilePlayProxyTicketMechanismeTestCaseEga extends MediaM
     // Get the asset.
     $asset = $this->getAsset($asset_id);
     $this->var_export($asset);
+
+    // Get default profile ID.
+    $default_profile_id = $this->getDefaultProfileId($asset['app_id']);
 
     // Get the mediafile_ids.
     $mediafile_ids = array();
@@ -98,7 +101,7 @@ class MediaMosaAssetMediafilePlayProxyTicketMechanismeTestCaseEga extends MediaM
     $parameters = array(
       mediamosa_rest_call_asset_mediafile_play::RESPONSE => mediamosa_asset_mediafile_play_proxy::RESPONSE_URI,
       mediamosa_rest_call_asset_mediafile_play::ORIGINAL_MEDIAFILE_ID => $mediafile_id_1,
-      mediamosa_rest_call_asset_mediafile_play::PROFILE_ID => 1,
+      mediamosa_rest_call_asset_mediafile_play::PROFILE_ID => $default_profile_id,
     );
     $xml = $this->play_proxy(__FILE__, __LINE__, $asset_id, $parameters, array(mediamosa_error::ERRORCODE_OKAY));
 
@@ -107,7 +110,7 @@ class MediaMosaAssetMediafilePlayProxyTicketMechanismeTestCaseEga extends MediaM
     $parameters = array(
       mediamosa_rest_call_asset_mediafile_play::RESPONSE => mediamosa_asset_mediafile_play_proxy::RESPONSE_URI,
       mediamosa_rest_call_asset_mediafile_play::ORIGINAL_MEDIAFILE_ID => $mediafile_id_2,
-      mediamosa_rest_call_asset_mediafile_play::PROFILE_ID => 1,
+      mediamosa_rest_call_asset_mediafile_play::PROFILE_ID => $default_profile_id,
     );
     $xml = $this->play_proxy(__FILE__, __LINE__, $asset_id, $parameters, array(mediamosa_error::ERRORCODE_OKAY));
 

--- a/sites/all/modules/mediamosa/modules/job/mediamosa_job.rest.class.inc
+++ b/sites/all/modules/mediamosa/modules/job/mediamosa_job.rest.class.inc
@@ -542,7 +542,7 @@ class mediamosa_rest_call_job_create extends mediamosa_rest_call {
         ),
         self::RETRANSCODE => array(
           self::VAR_TYPE => mediamosa_sdk::TYPE_BOOL,
-          self::VAR_DESCRIPTION => 'Retranscode after upload, user with upload jobs.',
+          self::VAR_DESCRIPTION => 'Retranscode after upload, used with upload jobs.',
           self::VAR_DEFAULT_VALUE => 'FALSE',
         ),
       )

--- a/sites/all/modules/mediamosa/simpletest/mediamosa.simpletest.class.inc
+++ b/sites/all/modules/mediamosa/simpletest/mediamosa.simpletest.class.inc
@@ -885,7 +885,7 @@ class MediaMosaTestCase extends DrupalWebTestCase {
     $fields[mediamosa_job_transcode_db::JOB_ID] = $job_id;
 
     $fields += array(
-      mediamosa_job_transcode_db::TRANSCODE_PROFILE_ID => 1,
+      mediamosa_job_transcode_db::TRANSCODE_PROFILE_ID => 16,
       mediamosa_job_transcode_db::TOOL => '',
       mediamosa_job_transcode_db::COMMAND => '',
       mediamosa_job_transcode_db::FILE_EXTENSION => '',

--- a/sites/all/modules/mediamosa/simpletest/mediamosa.simpletest.ega.class.inc
+++ b/sites/all/modules/mediamosa/simpletest/mediamosa.simpletest.ega.class.inc
@@ -1322,6 +1322,22 @@ class MediaMosaTestCaseEga extends MediaMosaTestCase {
   }
 
   /**
+   * Return the default Profile ID.
+   *
+   * @param $app_id
+   *   The Application ID.
+   */
+  protected function getDefaultProfileId($app_id) {
+    // Get the profile.
+    $profile = mediamosa_transcode_profile::get_default($app_id);
+
+    $this->assertTrue($profile, 'Found default transcode profile');
+    $this->var_export_verbose($profile);
+
+    return $profile[mediamosa_transcode_profile_db::ID];
+  }
+
+  /**
    * Get a mediaitem as oEmbed.
    * Based on the call /services/oembed (GET)
    */

--- a/sites/all/modules/mediamosa_solr/mediamosa_solr.class.inc
+++ b/sites/all/modules/mediamosa_solr/mediamosa_solr.class.inc
@@ -63,6 +63,7 @@ class mediamosa_solr {
   const ACL = 'acl';
   const ACL_NAME = 'name';
   const ACL_GRP = 'group';
+  const ACL_PLAYRESTRICTION = 'playrestriction';
 
   // ---------------------------------------------------------------- Functions.
   static public function asset_search($parameters) {
@@ -235,6 +236,13 @@ class mediamosa_solr {
 
     // Get of this current user the acl_name/acl_group ids so we know his/her access.
     $acl_ids = mediamosa_acl::build_access($build_access_app_ids, $acl_user_id, $acl_group_ids, $acl_domain, $acl_realm, $slaves);
+
+    if (!$granted && ($acl_type == mediamosa_acl::ACL_TYPE_ASSET || $acl_type == mediamosa_acl::ACL_TYPE_MEDIAFILE)) {
+      $now = mediamosa_datetime::utc_current_timestamp_now();
+      $now = drupal_substr($now, 0, 10) . 'T' . drupal_substr($now, 11, 8) . 'Z';
+      $solr_query[self::WHERE_AND][self::ACL_PLAYRESTRICTION][self::WHERE_AND][] = strtr('-(play_restriction_start:[* TO *] OR -play_restriction_start:[* TO :now])', array(':now' => mediamosa_solr_apache_solr_service::escape($now)));
+      $solr_query[self::WHERE_AND][self::ACL_PLAYRESTRICTION][self::WHERE_AND][] = strtr('-(play_restriction_end:[* TO *] OR -play_restriction_end:[:now TO *])', array(':now' => mediamosa_solr_apache_solr_service::escape($now)));
+    }
 
     if (!empty($acl_user_id) || !empty($acl_group_ids) || count($acl_ids) || count($slaves)) {
       // Even if we return all stuff where we have access to, we must still grant only access to master/slave apps
@@ -751,13 +759,13 @@ class mediamosa_solr {
 
           if ($found) {
             $found_total += $found;
-            self::deleteByQuery('app_id:' . $app_id);            
+            self::deleteByQuery('app_id:' . $app_id);
           }
         }
 
         // Commit.
         self::commit();
-        
+
         return $found_total;
       }
     }
@@ -851,6 +859,8 @@ class mediamosa_solr {
       mediamosa_asset_db::VIDEOTIMESTAMPMODIFIED,
       mediamosa_asset_db::CREATED,
       mediamosa_asset_db::CHANGED,
+      mediamosa_asset_db::PLAY_RESTRICTION_START,
+      mediamosa_asset_db::PLAY_RESTRICTION_END,
     );
 
     foreach ($asset_optionals_dates as $optional) {
@@ -1179,46 +1189,45 @@ class mediamosa_solr {
   }
 
   /**
-   * Create the WHERE syntax
+   * Create the WHERE syntax.
    *
-   * @param array $where
-   * @return string
-   */
-  static public function where($where) {
-    return implode(' AND ', self::where_2($where));
-  }
-
-  /**
-   * self::where helper function
+   * @param $where
+   *   Array that describes the query OR processed string.
+   * @param $glue
+   *   Either ' AND ' or ' OR '.
+   * @param $previous_glue
+   *   The previous used glue to prevent unnessary ( ).
    *
-   * @param array $where
-   * @param string $l
-   * @param string $r
-   * @param string $glue
-   * @return array
+   * @return
+   *   Return the created where string.
    */
-  static public function where_2($where, $l = '', $r = '', $glue = ' AND ') {
+  static public function where($where, $glue = ' AND ', $previous_glue = ' AND ') {
     if (!is_array($where)) {
-      return array($where);
+      return $where;
     }
 
     $result = array();
     foreach ($where as $type => $statements) {
       if ($type == self::WHERE_AND) {
-        $glue = " AND ";
-        $statements = self::where_2($statements, '(', ')', " AND ");
-        $result[] = $l . implode(" AND ", $statements) . $r;
+        $result[] = self::where($statements, ' AND ', $glue);
       }
       elseif ($type == self::WHERE_OR) {
-        $statements = self::where_2($statements, '(', ')', ' OR ');
-        $result[] = $l . implode(' OR ', $statements) . $r;
+        $result[] = self::where($statements, ' OR ', $glue);
       }
       else {
-        $result[] = implode($glue, self::where_2($statements, '(', ')', $glue));
+        $result[] = self::where($statements, $glue, $previous_glue);
       }
     }
 
-    return $result;
+    if ($glue == $previous_glue || count($result) < 2) {
+      $l = $r = '';
+    }
+    else {
+      $l = '(';
+      $r = ')';
+    }
+
+    return $l . implode($glue, $result) . $r;
   }
 
   /**

--- a/sites/all/modules/mediamosa_solr/mediamosa_solr.info
+++ b/sites/all/modules/mediamosa_solr/mediamosa_solr.info
@@ -34,6 +34,7 @@ files[] = tests/mediamosa_solr.acl.groups.master.slave.test
 files[] = tests/mediamosa_solr.acl.groups.test
 files[] = tests/mediamosa_solr.acl.master.slave.test
 files[] = tests/mediamosa_solr.acl.mediafiles.test
+files[] = tests/mediamosa_solr.acl.play_restriction.test
 files[] = tests/mediamosa_solr.acl.slave.rights.test
 files[] = tests/mediamosa_solr.acl.test
 

--- a/sites/all/modules/mediamosa_solr/schema.xml
+++ b/sites/all/modules/mediamosa_solr/schema.xml
@@ -3,7 +3,7 @@
 <!-- $Id: $ -->
 
 <!--
- This is the MediaMosa Solr schema file. This file should be named "schema.xml" 
+ This is the MediaMosa Solr schema file. This file should be named "schema.xml"
  and should be in the conf directory under the solr home
  (i.e. ./solr/conf/schema.xml by default)
  or located where the classloader for the Solr webapp can find it.
@@ -12,14 +12,14 @@
  http://wiki.apache.org/solr/SchemaXml
 -->
 
-<schema name="mediamosa-3.0.0-asset" version="1.2">
+<schema name="mediamosa-3.2.0-asset" version="1.2">
 
   <!-- attribute "name" is the name of this schema and is only used for display purposes.
        Applications should change this to reflect the nature of the search collection.
        version="1.2" is Solr's version number for the schema syntax and semantics.  It should
        not normally be changed by applications.
        1.0: multiValued attribute did not exist, all fields are multiValued by nature
-       1.1: multiValued attribute introduced, false by default 
+       1.1: multiValued attribute introduced, false by default
        1.2: omitTermFreqAndPositions attribute introduced, true by default except for text fields.
      -->
 
@@ -34,7 +34,7 @@
     -->
 
   <types>
-    <!-- 
+    <!--
       Each asset belongs to one app_id.
       -->
     <fieldType name="app_id" class="solr.TrieIntField" precisionStep="8" omitNorms="true" positionIncrementGap="0"/>
@@ -165,7 +165,7 @@
           -->
         <tokenizer class="solr.KeywordTokenizerFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
-      </analyzer> 
+      </analyzer>
     </fieldType>
 
     <!--
@@ -216,7 +216,7 @@
   <fields>
     <!-- Valid attributes for fields:
       name: mandatory - the name for the field
-       type: mandatory - the name of a previously defined type from the <types> 
+       type: mandatory - the name of a previously defined type from the <types>
        section
       indexed: true if this field should be indexed (searchable or sortable)
       stored: true if this field should be retrievable
@@ -232,9 +232,9 @@
         given field.
         When using MoreLikeThis, fields used for similarity should be
         stored for best performance.
-      termPositions: Store position information with the term vector.  
+      termPositions: Store position information with the term vector.
         This will increase storage costs.
-      termOffsets: Store offset information with the term vector. This 
+      termOffsets: Store offset information with the term vector. This
         will increase storage costs.
       default: a value that should be used if no value is specified
         when adding a document.
@@ -243,65 +243,68 @@
     <!--
       The app_id is always stored. (searchable, sortable)
       -->
-    <field name="app_id" type="app_id" indexed="true" stored="false" required="true" multiValued="false" /> 
+    <field name="app_id" type="app_id" indexed="true" stored="false" required="true" multiValued="false" />
 
     <!--
       The asset_id is always stored. (searchable, sortable)
       -->
-    <field name="asset_id" type="asset_id" indexed="true" stored="true" required="true" multiValued="false" /> 
-    
+    <field name="asset_id" type="asset_id" indexed="true" stored="true" required="true" multiValued="false" />
+
     <!--
-      The coll_id is optional. Asset can be in 0 or more collections. 
+      The coll_id is optional. Asset can be in 0 or more collections.
       (searchable, sortable)
-      
+
       Coll_id_ext is stored as;
       coll_id _ isprivate _ is_unappropriate
       coll_id _ owner_id
       -->
-    <field name="coll_id" type="string_id" indexed="true" stored="false" required="false" multiValued="true" /> 
-    <field name="coll_id_ext" type="string_id" indexed="true" stored="false" required="false" multiValued="true" /> 
-    <field name="coll_id_owner" type="string_id_ci" indexed="true" stored="false" required="false" multiValued="true" /> 
-    <field name="mediafile_id" type="string_id" indexed="true" stored="false" required="false" multiValued="true" /> 
+    <field name="coll_id" type="string_id" indexed="true" stored="false" required="false" multiValued="true" />
+    <field name="coll_id_ext" type="string_id" indexed="true" stored="false" required="false" multiValued="true" />
+    <field name="coll_id_owner" type="string_id_ci" indexed="true" stored="false" required="false" multiValued="true" />
+    <field name="mediafile_id" type="string_id" indexed="true" stored="false" required="false" multiValued="true" />
 
     <!--
       User fav.
       stored as; app_id _ username
       -->
-    <field name="user_fav" type="string_id_ci" indexed="true" stored="false" required="false" multiValued="true" /> 
+    <field name="user_fav" type="string_id_ci" indexed="true" stored="false" required="false" multiValued="true" />
 
-    <field name="owner_id" type="string_id_ci" indexed="true" stored="false" required="false" multiValued="false" /> 
-    <field name="group_id" type="string_id_ci" indexed="true" stored="false" required="false" multiValued="false" /> 
-    <field name="provider_id" type="string_id_ci" indexed="true" stored="false" required="false" multiValued="false" /> 
-    <field name="reference_id" type="string_id_ci" indexed="true" stored="false" required="false" multiValued="false" /> 
-    
-    <field name="mediafile_duration" type="string" indexed="true" stored="false" required="false" multiValued="false" /> 
-    <field name="mediafile_container_type" type="string" indexed="true" stored="false" required="false" multiValued="false" /> 
+    <field name="owner_id" type="string_id_ci" indexed="true" stored="false" required="false" multiValued="false" />
+    <field name="group_id" type="string_id_ci" indexed="true" stored="false" required="false" multiValued="false" />
+    <field name="provider_id" type="string_id_ci" indexed="true" stored="false" required="false" multiValued="false" />
+    <field name="reference_id" type="string_id_ci" indexed="true" stored="false" required="false" multiValued="false" />
 
-    <field name="mime_type" type="string" indexed="true" stored="false" required="false" multiValued="true" /> 
-    <field name="filename" type="string" indexed="true" stored="false" required="false" multiValued="true" /> 
-    <field name="uri" type="string" indexed="true" stored="false" required="false" multiValued="true" /> 
-    
-    <field name="videotimestamp" type="date" indexed="true" stored="false" required="false" multiValued="false" /> 
-    <field name="videotimestampmodified" type="date" indexed="true" stored="false" required="false" multiValued="false" /> 
-    <field name="created" type="date" indexed="true" stored="false" required="false" multiValued="false" /> 
-    <field name="changed" type="date" indexed="true" stored="false" required="false" multiValued="false" /> 
+    <field name="play_restriction_start" type="date" indexed="true" stored="false" required="false" multiValued="false" />
+    <field name="play_restriction_end" type="date" indexed="true" stored="false" required="false" multiValued="false" />
 
-    <field name="viewed" type="int" indexed="true" stored="false" required="true" multiValued="false" /> 
-    <field name="played" type="int" indexed="true" stored="false" required="true" multiValued="false" /> 
+    <field name="mediafile_duration" type="string" indexed="true" stored="false" required="false" multiValued="false" />
+    <field name="mediafile_container_type" type="string" indexed="true" stored="false" required="false" multiValued="false" />
+
+    <field name="mime_type" type="string" indexed="true" stored="false" required="false" multiValued="true" />
+    <field name="filename" type="string" indexed="true" stored="false" required="false" multiValued="true" />
+    <field name="uri" type="string" indexed="true" stored="false" required="false" multiValued="true" />
+
+    <field name="videotimestamp" type="date" indexed="true" stored="false" required="false" multiValued="false" />
+    <field name="videotimestampmodified" type="date" indexed="true" stored="false" required="false" multiValued="false" />
+    <field name="created" type="date" indexed="true" stored="false" required="false" multiValued="false" />
+    <field name="changed" type="date" indexed="true" stored="false" required="false" multiValued="false" />
+
+    <field name="viewed" type="int" indexed="true" stored="false" required="true" multiValued="false" />
+    <field name="played" type="int" indexed="true" stored="false" required="true" multiValued="false" />
 
     <!--
-      The batch_id is optional. Asset can be in 0 or more batches. 
+      The batch_id is optional. Asset can be in 0 or more batches.
       (searchable, sortable)
       -->
-    <field name="batch_id" type="int" indexed="true" stored="false" required="false" multiValued="true" /> 
+    <field name="batch_id" type="int" indexed="true" stored="false" required="false" multiValued="true" />
 
-    <!-- 
+    <!--
       Is empty asset flag.
       -->
-    <field name="is_empty_asset" type="boolean" indexed="true" stored="false" required="true" multiValued="false" /> 
-    <field name="isprivate" type="boolean" indexed="true" stored="false" required="true" multiValued="false" /> 
-    <field name="is_unappropriate" type="boolean" indexed="true" stored="false" required="true" multiValued="false" /> 
-    <field name="is_external" type="boolean" indexed="true" stored="false" required="true" multiValued="false" /> 
+    <field name="is_empty_asset" type="boolean" indexed="true" stored="false" required="true" multiValued="false" />
+    <field name="isprivate" type="boolean" indexed="true" stored="false" required="true" multiValued="false" />
+    <field name="is_unappropriate" type="boolean" indexed="true" stored="false" required="true" multiValued="false" />
+    <field name="is_external" type="boolean" indexed="true" stored="false" required="true" multiValued="false" />
 
     <!--
       ACL. rules.
@@ -309,58 +312,58 @@
 
       mf_org:[TRUE|FALSE] (TRUE: has 1 or more original mf)
 
-      mf_org_acl_obj_acl_[name|group][]: 
+      mf_org_acl_obj_acl_[name|group][]:
 
       mf_org_acl_obj_[owner|group][]:
 
-      mf_acl_master_slave[]: 
+      mf_acl_master_slave[]:
       is_protected; TRUE: TRUE or DOMAIN_REALM. FALSE: FALSE or USER_USERGROUP
       acl_type_acl_id; is only set when is_protected is != FALSE.
       app_id _ slave_app_id _ master_is_protected _ [acl_type _ acl_id]
-      
+
       -->
-    <field name="mf" type="boolean" indexed="true" stored="false" required="true" multiValued="false" /> 
-    <field name="mf_org" type="boolean" indexed="true" stored="false" required="true" multiValued="false" /> 
-    <field name="mf_org_is_protected" type="int" indexed="true" stored="false" required="false" multiValued="true" /> 
-    <field name="mf_org_acl_obj_acl_name" type="int" indexed="true" stored="false" required="false" multiValued="true" /> 
-    <field name="mf_org_acl_obj_acl_group" type="int" indexed="true" stored="false" required="false" multiValued="true" /> 
-    
+    <field name="mf" type="boolean" indexed="true" stored="false" required="true" multiValued="false" />
+    <field name="mf_org" type="boolean" indexed="true" stored="false" required="true" multiValued="false" />
+    <field name="mf_org_is_protected" type="int" indexed="true" stored="false" required="false" multiValued="true" />
+    <field name="mf_org_acl_obj_acl_name" type="int" indexed="true" stored="false" required="false" multiValued="true" />
+    <field name="mf_org_acl_obj_acl_group" type="int" indexed="true" stored="false" required="false" multiValued="true" />
+
     <!--
       string_id[_ci] type on these are very important.
       -->
-    <field name="mf_org_owner" type="string_id_ci" indexed="true" stored="false" required="false" multiValued="true" /> 
-    <field name="mf_org_group" type="string_id_ci" indexed="true" stored="false" required="false" multiValued="true" /> 
-    <field name="mf_acl_master_slave" type="string_id" indexed="true" stored="false" required="false" multiValued="true" /> 
+    <field name="mf_org_owner" type="string_id_ci" indexed="true" stored="false" required="false" multiValued="true" />
+    <field name="mf_org_group" type="string_id_ci" indexed="true" stored="false" required="false" multiValued="true" />
+    <field name="mf_acl_master_slave" type="string_id" indexed="true" stored="false" required="false" multiValued="true" />
 
     <!--
       ACL CQL context set.
       The ACL CQL context set supports allows EGAs to search on their acl settings.
-      
+
       mf_acl_user: mediamosa_acl_name.USER
       mf_acl_user_group: mediamosa_acl_name.USER_GROUP
       mf_acl_domain: mediamosa_acl_name.DOMAIN
       mf_acl_realm: mediamosa_acl_name.REALM
       mf_acl_realm_prefix: mediamosa_acl_name.REALM_PREFIX
       -->
-    <field name="mf_app_id_master" type="int" indexed="true" stored="false" required="false" multiValued="true" /> 
-    <field name="mf_app_id_slave" type="int" indexed="true" stored="false" required="false" multiValued="true" /> 
-    <field name="asset_is_master_slaved" type="boolean" indexed="true" stored="false" required="true" multiValued="false" /> 
-    <field name="mf_is_protected" type="boolean" indexed="true" stored="false" required="false" multiValued="true" /> 
-    <field name="mf_acl_user" type="string_id_ci" indexed="true" stored="false" required="false" multiValued="true" /> 
-    <field name="mf_acl_user_group" type="string_id_ci" indexed="true" stored="false" required="false" multiValued="true" /> 
-    <field name="mf_acl_domain" type="string_id_ci" indexed="true" stored="false" required="false" multiValued="true" /> 
-    <field name="mf_acl_realm" type="string_id_ci" indexed="true" stored="false" required="false" multiValued="true" /> 
-    <field name="mf_acl_realm_prefix" type="string_id_ci" indexed="true" stored="false" required="false" multiValued="true" /> 
+    <field name="mf_app_id_master" type="int" indexed="true" stored="false" required="false" multiValued="true" />
+    <field name="mf_app_id_slave" type="int" indexed="true" stored="false" required="false" multiValued="true" />
+    <field name="asset_is_master_slaved" type="boolean" indexed="true" stored="false" required="true" multiValued="false" />
+    <field name="mf_is_protected" type="boolean" indexed="true" stored="false" required="false" multiValued="true" />
+    <field name="mf_acl_user" type="string_id_ci" indexed="true" stored="false" required="false" multiValued="true" />
+    <field name="mf_acl_user_group" type="string_id_ci" indexed="true" stored="false" required="false" multiValued="true" />
+    <field name="mf_acl_domain" type="string_id_ci" indexed="true" stored="false" required="false" multiValued="true" />
+    <field name="mf_acl_realm" type="string_id_ci" indexed="true" stored="false" required="false" multiValued="true" />
+    <field name="mf_acl_realm_prefix" type="string_id_ci" indexed="true" stored="false" required="false" multiValued="true" />
 
     <!--
       Because mediamosa supports custom metadata, we must use dynamic fields for
-      all metadata, including dc, qdc and czp. 
-      
+      all metadata, including dc, qdc and czp.
+
       All metadata fields can be multivalued. However, sort fields in solr must
       be non-multi. Depending on the sort order, lo or hi field is used. These
       fields hold either the highest or the lowest value of the same field.
       -->
-    
+
     <!-- Searchable fields -->
     <dynamicField name="*_vc" type="val_char" indexed="true" stored="false" multiValued="true"/>
     <dynamicField name="*_vi" type="val_int" indexed="true" stored="false" multiValued="true"/>
@@ -385,7 +388,7 @@
      -->
   </fields>
 
-  <!-- Field to use to determine and enforce document uniqueness. 
+  <!-- Field to use to determine and enforce document uniqueness.
     Unless this field is marked with required="false", it will be a required field
   -->
   <uniqueKey>asset_id</uniqueKey>

--- a/sites/all/modules/mediamosa_solr/tests/mediamosa_solr.acl.play_restriction.test
+++ b/sites/all/modules/mediamosa_solr/tests/mediamosa_solr.acl.play_restriction.test
@@ -1,0 +1,110 @@
+<?php
+// $Id$
+
+/**
+ * MediaMosa is Open Source Software to build a Full Featured, Webservice
+ * Oriented Media Management and Distribution platform (http://mediamosa.org)
+ *
+ * Copyright (C) 2009 SURFnet BV (http://www.surfnet.nl) and Kennisnet
+ * (http://www.kennisnet.nl)
+ *
+ * MediaMosa is based on the open source Drupal platform and
+ * was originally developed by Madcap BV (http://www.madcap.nl)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, you can find it at:
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+ */
+
+/**
+ * @file
+ * Solr version of MediaMosaAclPlayRestrictionTestCaseEga
+ */
+
+class MediaMosaSolrAclPlayRestrictionTestCaseEga extends MediaMosaAclPlayRestrictionTestCaseEga {
+  // ------------------------------------------------------------------ Members.
+
+  // ------------------------------------------------------------------ Functions.
+  public static function getInfo() {
+    $info = parent::getInfo();
+    $info['name'] = 'SOLR - ' . $info['name'];
+    $info['group'] = 'MediaMosa Solr';
+    $info['automatic_run_disabled'] = module_exists('mediamosa_solr') ? FALSE : TRUE;
+
+    return $info;
+  }
+
+  /**
+   * Make sure SOLR is on.
+   */
+  public static function mediamosa_run_enabled() {
+    return module_exists('mediamosa_solr') ? TRUE : FALSE;
+  }
+
+  /**
+   * Implements setUp().
+   *
+   * Any changes; see other classes(!)
+   */
+  protected function setUp() {
+    // Get Solr url from parent install.
+    $mediamosa_solr_url = mediamosa_solr_apache_solr_service::mediamosaGetUrl();
+
+    // Run parent first so we are inside sandbox.
+    // Call parent::setUp and preserve arguments.
+    $args = func_get_args();
+
+    $args = array_unique(array_merge(array(
+      'mediamosa_solr',
+    ), $args));
+
+    // PHP 5.3 does not allow to use $this as we do here.
+    if (drupal_substr(phpversion(), 0, 3) < '5.3') {
+      call_user_func_array(array($this, 'parent::setUp'), $args);
+    }
+    else {
+      call_user_func_array('parent::setUp', $args);
+    }
+
+    // Solr set url.
+    variable_set('mediamosa_solr_url', $mediamosa_solr_url);
+
+    // Turn on Solr as search engine.
+    variable_set('mediamosa_search_engine', 'mediamosa_solr');
+  }
+
+  /**
+   * Implements tearDown().
+   *
+   * Any changes; see other classes(!)
+   */
+  protected function tearDown() {
+
+    $app_ids = array();
+    if (!empty($this->a_app['app_id'])) {
+      $app_ids[] = $this->a_app['app_id'];
+    }
+    if (!empty($this->a_app_2['app_id'])) {
+      $app_ids[] = $this->a_app_2['app_id'];
+    }
+    if (!empty($this->a_app_3['app_id'])) {
+      $app_ids[] = $this->a_app_3['app_id'];
+    }
+
+    // Teardown first (else teardown will sync assets sometimes to SOLR).
+    parent::tearDown();
+
+    // Remove it.
+    if (!empty($app_ids)) {
+      mediamosa_solr::delete_simpletest_documents($app_ids);
+    }
+  }
+}

--- a/sites/all/modules/mediamosa_solr/tests/mediamosa_solr.test
+++ b/sites/all/modules/mediamosa_solr/tests/mediamosa_solr.test
@@ -55,7 +55,7 @@ class MediaMosaSolrTestCaseEga extends MediaMosaTestCaseEgaJob {
   protected function setUp() {
     // Get Solr url from parent install.
     $mediamosa_solr_url = mediamosa_solr_apache_solr_service::mediamosaGetUrl();
-    
+
     // Change app timezones to UTC default.
     $this->default_timezone = mediamosa_settings::MEDIAMOSA_DEFAULT_TIMEZONE_INTERNAL;
 

--- a/sites/all/modules/mediamosa_tool_ffmpeg/mediamosa_tool_ffmpeg.install
+++ b/sites/all/modules/mediamosa_tool_ffmpeg/mediamosa_tool_ffmpeg.install
@@ -107,14 +107,14 @@ function mediamosa_tool_ffmpeg_install() {
     // same as before but now with default profile.
     array('mp4 h264 low quality', 'FALSE', 'ffmpeg', 'mp4', 'audiocodec:libfaac;audiochannels:1;videocodec:libx264;videobitrate:56000;fps:12;size:176x144;maintain_aspect_ratio:yes'),
     array('mp4 h264 medium quality', 'FALSE', 'ffmpeg', 'mp4', 'audiocodec:libfaac;audiobitrate:64000;audiochannels:2;videocodec:libx264;videobitrate:360000;fps:25;maintain_aspect_ratio:yes;size:480x320'),
-    array('mp4 h264 high quality', 'TRUE', 'ffmpeg', 'mp4', 'audiocodec:libfaac;audiobitrate:128000;audiosamplingrate:44100;audiochannels:2;videocodec:libx264;videobitrate:500000;fps:30;size:480x360;maintain_aspect_ratio:yes'),
+    array('mp4 h264 high quality', 'FALSE', 'ffmpeg', 'mp4', 'audiocodec:libfaac;audiobitrate:128000;audiosamplingrate:44100;audiochannels:2;videocodec:libx264;videobitrate:500000;fps:30;size:480x360;maintain_aspect_ratio:yes'),
     array('mp4 h264 HD - 2kbps', 'FALSE', 'ffmpeg', 'mp4', 'audiocodec:libfaac;audiobitrate:192000;audiosamplingrate:44100;audiochannels:2;videocodec:libx264;videobitrate:2000000;fps:30;size:1280x720;maintain_aspect_ratio:yes'),
     array('mp4 h264 HD - 4kbps', 'FALSE', 'ffmpeg', 'mp4', 'audiocodec:libfaac;audiobitrate:192000;audiosamplingrate:44100;audiochannels:2;videocodec:libx264;videobitrate:4000000;fps:30;size:1280x720;maintain_aspect_ratio:yes'),
 
     // h264 lossless profiles.
-    
-    // mpeg4
-    array('mpeg4 default', 'FALSE', 'ffmpeg', 'mpeg', 'videocodec:mpeg4'),
+
+    // mpeg4, default profile, as this profile will work on ffmpeg 0.7 ad 0.9.
+    array('mpeg4 default', 'TRUE', 'ffmpeg', 'mpeg', 'videocodec:mpeg4'),
 
     // mpeg4 iphone format (untested)
     array('mpeg4 iphone', 'FALSE', 'ffmpeg', 'mp4', 'audiocodec:libfaac;audiobitrate:128000;audiochannels:2;videocodec:mpeg4;videobitrate:800000;size:240x160'),


### PR DESCRIPTION
```
- Added play restriction ACL; media that does meet play restriction rules (when
  set on asset) fail play access.
- Fixed: When update on asset the play_restriction_start and
         play_restriction_end are switched (high to low instead of low to
         high), then MediaMosa will swap the date values.
- Added simpletest for testing play restriction.
- Fixed: Default profile is now profile 16 in a clean install (broke
         simpletests in clean install).
- Note: The XML schema of the Solr module has been changed, existing
        installations that use MediaMosa Solr must replace their schema.xml
        (found in /sites/all/modules/mediamosa_solr/schema.xml) in their Solr
        installation.
```
