### PR TITLE
Clear messages session variable after each ReST call

### DIFF
--- a/sites/all/modules/mediamosa/rest/mediamosa_rest_call.class.inc
+++ b/sites/all/modules/mediamosa/rest/mediamosa_rest_call.class.inc
@@ -286,6 +286,9 @@ abstract class mediamosa_rest_call {
     // Call the function.
     $this->do_call();
 
+    // Make sure no error message queue builds up in the session
+    drupal_get_messages();
+
     return $this->{self::RESPONSE_TYPE};
   }
 


### PR DESCRIPTION
Drupal adds PHP error messages to the session variable "messages".
This variable is displayed and emptied when normal HTML pages are
displayed. However, ReST calls do not display these messages, and
the errors will keep accumulating. After enough ReST calls, the
message variable becomes large enough (>24MB) for the mysql client to
abort.

This patch clears the messages variable after each ReST call so the
variable doesn't keep growing infinitely.
