### PR TITLE
Added {ASPECT_RATIO} and {ASPECT_RATIO_PERC}.

### DIFF
--- a/sites/all/modules/mediamosa/core/media/mediamosa_media.class.inc
+++ b/sites/all/modules/mediamosa/core/media/mediamosa_media.class.inc
@@ -793,11 +793,21 @@ class mediamosa_media {
         $output = str_replace('{/' . $if_tag . '}', '', $output);
       }
     }
-
+    // Calculate aspect ratio.
+    if (($mediafile_width == 0) or ($mediafile_height == 0) or (empty($mediafile_width)) or (empty($mediafile_height))) {
+      // Defaults to 16:9.
+      $aspect_ratio = 16 / 9;
+    }
+    else {
+      $aspect_ratio = ($mediafile_width / $mediafile_height);
+    }
+    $aspect_ratio_perc = (1 / $aspect_ratio) * 100;
     $variables = array(
       '{WIDTH}' => !$video_size['width'] ? '' : $video_size['width'],
       '{HEIGHT}' => !$video_size['height'] ? '' : $video_size['height'],
       '{HEIGHT_PLUS_20}' => $video_size['height'] > 0 ? $video_size['height'] + 20 : '',
+      '{ASPECT_RATIO}' => round($aspect_ratio, 2),
+      '{ASPECT_RATIO_PERC}' => (round($aspect_ratio_perc, 2)),
       '{MEDIAFILE_ID}' => $mediafile[mediamosa_asset_mediafile_db::ID],
       '{TICKET_URI}' => $server_uri_build,
       '{STILL_URI}' => self::do_response_still_default($app_id, $mediafile[mediamosa_asset_mediafile_db::ASSET_ID]),


### PR DESCRIPTION
In the server object code. This will make a resizable player more easy. For example with videojs:

```
<style type="text/css">
  .video-js {padding-top: {ASPECT_RATIO_PERC}%;}
  .vjs-fullscreen {padding-top:0;}
</style>

<div class="v" style="width=100%; max-width="{WIDTH}px;">
<video id="MediaMosa_video_1" class="video-js vjs-default-skin"  controls preload="auto" width="auto" height="auto" poster="{STILL_URI}" data-setup="">
 <source src="{TICKET_URI}" type='video/mp4'>
</video>
</div>
```
