### PR TITLE
Refactured Analyse process with hooks.

### DIFF
--- a/sites/all/modules/mediamosa/core/asset/mediafile/mediamosa_asset_mediafile.class.inc
+++ b/sites/all/modules/mediamosa/core/asset/mediafile/mediamosa_asset_mediafile.class.inc
@@ -784,60 +784,6 @@ class mediamosa_asset_mediafile {
   }
 
   /**
-   * Analyse the mediafile and store it into the database metadata of mediafile.
-   *
-   * @param integer $app_id
-   *   The client application ID.
-   * @param string $mediafile_id
-   *   The ID of the mediafile to analyse.
-   * @param string $execution_string
-   *   The execution string for the analyse.
-   *
-   * @return array
-   *   The output of the executed batch.
-   */
-  public static function analyse($app_id, $mediafile_id, $execution_string = '') {
-
-    $options = array();
-    if ($app_id) {
-      // Get the app.
-      $mediamosa_app = mediamosa_app::get_by_appid($app_id);
-
-      if ($mediamosa_app[mediamosa_app_db::ALWAYS_HINT_MP4] == mediamosa_app_db::ALWAYS_HINT_MP4_TRUE) {
-        $options[] =  mediamosa_settings::ANALYSE_FILE_ALWAYS_HINT_MP4_OPTION;
-      }
-
-      if ($mediamosa_app[mediamosa_app_db::ALWAYS_INSERT_MD] == mediamosa_app_db::ALWAYS_INSERT_MD_TRUE) {
-        $options[] =  mediamosa_settings::ANALYSE_FILE_ALWAYS_INSERT_MD_OPTION;
-      }
-    }
-
-    $execution_string = sprintf('%s %s %s',
-      mediamosa_settings::lua_analyse_script(),
-      mediamosa_storage::get_local_mediafile_path($mediafile_id),
-      $mediafile_id
-    );
-
-    $execution_string .= (count($options) ? ' ' . implode(' ', $options) : '');
-
-    // Return the result from the exec.
-    $analyse_result =  mediamosa_io::exec($execution_string . ' 2>&1');
-
-    // Store parsed result.
-    $parsed_analyse_result = array();
-
-    // Walk through results and make proper array.
-    foreach ($analyse_result as $line) {
-      if (strpos($line, ':') !== FALSE) {
-        list($name, $value) = explode(':', $line, 2);
-        $parsed_analyse_result[trim($name)] = trim($value);
-      }
-    }
-
-    return $parsed_analyse_result;
-  }
-
-  /**
    * Returns TRUE/FALSE if the mediafile is an original.
    *
    * @param array $mediafile

--- a/sites/all/modules/mediamosa/core/asset/mediafile/metadata/mediamosa_asset_mediafile_metadata.class.inc
+++ b/sites/all/modules/mediamosa/core/asset/mediafile/metadata/mediamosa_asset_mediafile_metadata.class.inc
@@ -134,23 +134,6 @@ class mediamosa_asset_mediafile_metadata {
   }
 
   /**
-   * Calculate the bits per plane.
-   *
-   * @param $width
-   * @param $height
-   * @param $fps
-   * @param $bitrate
-   */
-  static function calculate_bpp($width, $height, $fps, $bitrate) {
-    $result = '';
-    if ($width != '' && $height != '' && $fps != '' && $bitrate != '') {
-      $result = round((($bitrate * 1000) / ($fps * $width * $height)), 2);
-    }
-
-    return $result;
-  }
-
-  /**
    * Fill the mediafile metadata.
    *
    * @param string $still_id
@@ -223,7 +206,7 @@ class mediamosa_asset_mediafile_metadata {
   /**
    * Parse and store the returned data from the analyse.
    *
-   * @param string mediafile_id
+   * @param string $mediafile_id
    *   The mediafile ID.
    * @param array $metadata
    *   The name-value pair array.
@@ -241,9 +224,6 @@ class mediamosa_asset_mediafile_metadata {
     // Get the filesize.
     $filesize = mediamosa_io::filesize($mediafile_uri);
 
-    $mimetype = mediamosa_mimetype::get_mime_type($mediafile_uri);
-    self::create_mediafile_metadata($mediafile_id, $mimetype, mediamosa_asset_mediafile_metadata::MIME_TYPE, mediamosa_asset_mediafile_metadata_property_db::TYPE_CHAR);
-
     // Get the md5.
     $md5 = mediamosa_io::md5_file($mediafile_uri);
 
@@ -253,65 +233,10 @@ class mediamosa_asset_mediafile_metadata {
     // Create md5 metadata.
     self::create_mediafile_metadata_char($mediafile_id, $md5, mediamosa_asset_mediafile_metadata::MD5);
 
-    // Store analyse.
-    //
-    // Video-codec.
-    $value = isset($metadata['Video-codec']) ? $metadata['Video-codec'] : '';
-    self::create_mediafile_metadata($mediafile_id, $value, mediamosa_asset_mediafile_metadata::VIDEO_CODEC, mediamosa_asset_mediafile_metadata_property_db::TYPE_CHAR);
-
-    // Video-colorspace.
-    $value = isset($metadata['Video-colorspace']) ? $metadata['Video-colorspace'] : '';
-    self::create_mediafile_metadata($mediafile_id, $value, mediamosa_asset_mediafile_metadata::COLORSPACE, mediamosa_asset_mediafile_metadata_property_db::TYPE_CHAR);
-
-    // Video-size.
-    list($width, $height) = isset($metadata['Video-size']) ? explode('x', $metadata['Video-size']) : array(0, 0);
-    self::create_mediafile_metadata($mediafile_id, $width, mediamosa_asset_mediafile_metadata::WIDTH, mediamosa_asset_mediafile_metadata_property_db::TYPE_INT);
-    self::create_mediafile_metadata($mediafile_id, $height, mediamosa_asset_mediafile_metadata::HEIGHT, mediamosa_asset_mediafile_metadata_property_db::TYPE_INT);
-
-    // Video-framespersecond.
-    $fps = isset($metadata['Video-framespersecond']) ? $metadata['Video-framespersecond'] : '';
-    self::create_mediafile_metadata($mediafile_id, $fps, mediamosa_asset_mediafile_metadata::FPS, mediamosa_asset_mediafile_metadata_property_db::TYPE_CHAR);
-
-    // Audio-codec.
-    $value = isset($metadata['Audio-codec']) ? $metadata['Audio-codec'] : '';
-    self::create_mediafile_metadata($mediafile_id, $value, mediamosa_asset_mediafile_metadata::AUDIO_CODEC, mediamosa_asset_mediafile_metadata_property_db::TYPE_CHAR);
-
-    // Audio-frequency.
-    $value = isset($metadata['Audio-frequency']) ? $metadata['Audio-frequency'] : '0';
-    self::create_mediafile_metadata($mediafile_id, $value, mediamosa_asset_mediafile_metadata::SAMPLE_RATE, mediamosa_asset_mediafile_metadata_property_db::TYPE_INT);
-
-    // Audio-channels.
-    $value = isset($metadata['Audio-channels']) ? $metadata['Audio-channels'] : '';
-    self::create_mediafile_metadata($mediafile_id, $value, mediamosa_asset_mediafile_metadata::CHANNELS, mediamosa_asset_mediafile_metadata_property_db::TYPE_CHAR);
-
-    // file-duration.
-    $value = isset($metadata['File-duration']) ? $metadata['File-duration'] : '';
-    self::create_mediafile_metadata($mediafile_id, $value, mediamosa_asset_mediafile_metadata::FILE_DURATION, mediamosa_asset_mediafile_metadata_property_db::TYPE_CHAR);
-
-    // container.
-    $value = isset($metadata['File-type']) ? $metadata['File-type'] : '';
-    self::create_mediafile_metadata($mediafile_id, $value, mediamosa_asset_mediafile_metadata::CONTAINER_TYPE, mediamosa_asset_mediafile_metadata_property_db::TYPE_CHAR);
-
-    // file-bitrate.
-    $bitrate = isset($metadata['File-bitrate']) ? intval($metadata['File-bitrate']) : '0';
-    if ($bitrate) {
-      // Don't store invalid data.
-      self::create_mediafile_metadata($mediafile_id, $bitrate, mediamosa_asset_mediafile_metadata::BITRATE, mediamosa_asset_mediafile_metadata_property_db::TYPE_INT);
+    // Store metadata from analyse.
+    foreach ($metadata as $property => $value) {
+      self::create_mediafile_metadata($mediafile_id, $value['value'], $property, $value['type']);
     }
-
-    // bpp.
-    $value = (string) self::calculate_bpp($width, $height, $fps, $bitrate);
-    self::create_mediafile_metadata($mediafile_id, $value, mediamosa_asset_mediafile_metadata::BPP, mediamosa_asset_mediafile_metadata_property_db::TYPE_CHAR);
-
-    // is hinted.
-    $value = isset($metadata['Is-hinted']) ? $metadata['Is-hinted'] : 'no';
-    $value = strcasecmp($value, 'yes') == 0 ? 'TRUE' : 'FALSE';
-    self::create_mediafile_metadata($mediafile_id, $value, mediamosa_asset_mediafile_metadata::IS_HINTED, mediamosa_asset_mediafile_metadata_property_db::TYPE_CHAR);
-
-    // has inserted extra metadata.
-    $value = isset($metadata['Is-inserted-md']) ? $metadata['Is-inserted-md'] : 'no';
-    $value = strcasecmp($value, 'yes') == 0 ? 'TRUE' : 'FALSE';
-    self::create_mediafile_metadata($mediafile_id, $value, mediamosa_asset_mediafile_metadata::IS_INSERTED_MD, mediamosa_asset_mediafile_metadata_property_db::TYPE_CHAR);
 
     // The output of ffmpeg.
     $ffmpeg_output = isset($metadata['ffmpeg-output']) ? implode('\n', explode('}-{', $metadata['ffmpeg-output'])) : '';

--- a/sites/all/modules/mediamosa/core/job/mediamosa_job.class.inc
+++ b/sites/all/modules/mediamosa/core/job/mediamosa_job.class.inc
@@ -970,7 +970,7 @@ class mediamosa_job {
     $mediafile_id = $job_ext_upload[mediamosa_job_db::MEDIAFILE_ID];
 
     // Analyse the mediafile.
-    $analyse_result = mediamosa_asset_mediafile::analyse($job_ext_upload[mediamosa_job_db::APP_ID], $job_ext_upload[mediamosa_job_db::MEDIAFILE_ID]);
+    $analyse_result = mediamosa_job_server::analyse($job_ext_upload[mediamosa_job_db::MEDIAFILE_ID], $job_ext_upload[mediamosa_job_db::ID]);
 
     // Store it.
     mediamosa_asset_mediafile_metadata::store_analyse($job_ext_upload[mediamosa_job_db::ID], $analyse_result);
@@ -1100,7 +1100,7 @@ class mediamosa_job {
         // Check if the tool is enabled for this app.
         if (isset($tool_analyse[key($tool_info)])) {
           // Start the analyse process.
-          module_invoke($module, 'mediamosa_tool_analyse', $job_ext);
+          module_invoke($module, 'mediamosa_tool_analyse_metadata', $job_ext);
           break;
         }
       }

--- a/sites/all/modules/mediamosa/core/job/scheduler/mediamosa_job_scheduler.class.inc
+++ b/sites/all/modules/mediamosa/core/job/scheduler/mediamosa_job_scheduler.class.inc
@@ -468,7 +468,7 @@ class mediamosa_job_scheduler {
     }
 
     // Analyse the mediafile.
-    $analyse_result = mediamosa_asset_mediafile::analyse($job_info['app_id'], (string) $mediafile_id_dest);
+    $analyse_result = mediamosa_job_server::analyse((string) $mediafile_id_dest, $job_id);
 
     // Store it.
     mediamosa_asset_mediafile_metadata::store_analyse_without_job($job_id, $analyse_result, (string) $mediafile_id_dest);

--- a/sites/all/modules/mediamosa/core/job/server/mediamosa_job_server.class.inc
+++ b/sites/all/modules/mediamosa/core/job/server/mediamosa_job_server.class.inc
@@ -381,14 +381,16 @@ class mediamosa_job_server {
         mediamosa_io::unlink(mediamosa_storage::get_realpath_status_file($job_id));
 
         $execution_string = self::get_transcode_exec($jobserver_job_id, $mediafile_id_src);
+        self::log_mediafile($mediafile_id_src, 'About to start @job_type job: @job_id calling exec: @execution_string', array('@job_type' => $job_type, '@job_id' => $job_id, '@execution_string' => $execution_string));
         break;
 
       case mediamosa_job_server_db::JOB_TYPE_STILL:
         $execution_string = self::get_generate_still_exec($jobserver_job_id, $mediafile_id_src);
+        self::log_mediafile($mediafile_id_src, 'About to start @job_type job: @job_id calling exec: @execution_string', array('@job_type' => $job_type, '@job_id' => $job_id, '@execution_string' => $execution_string));
         break;
 
       case mediamosa_job_server_db::JOB_TYPE_ANALYSE:
-        $execution_string = self::get_analyse_string($mediafile_id_src, $job_id);
+        // See below.
         break;
 
       default:
@@ -397,25 +399,14 @@ class mediamosa_job_server {
         return FALSE;
     }
 
-    // Log our action.
-    self::log_mediafile($mediafile_id_src, 'About to start @job_type job: @job_id calling exec: @execution_string', array('@job_type' => $job_type, '@job_id' => $job_id, '@execution_string' => $execution_string));
-
     // Set job in progress.
     self::set_job_status($job_id, mediamosa_job_server_db::JOB_STATUS_INPROGRESS, '0.000');
 
-    // Now execute analyse directly, as its really fast.
+    // Now execute analyse directly, as it should be fast.
     if ($job_type == mediamosa_job_server_db::JOB_TYPE_ANALYSE) {
-      $analyse_result = mediamosa_asset_mediafile::analyse(0, $mediafile_id_src, $execution_string);
 
-      $link_asset = self::get_asset_link($job_id);
-      self::log_mediafile($mediafile_id_src, 'Job @job_type (Job ID: @job_id) returned output: @output<br /><br />@link',
-        array(
-          '@job_type' => $job_type,
-          '@job_id' => $job_id,
-          '@output' => print_r($analyse_result, TRUE),
-          '@link' => $link_asset,
-        )
-      );
+      // Call all modules that can analyse.
+      $analyse_result = self::analyse($mediafile_id_src, $job_id);
 
       if (!empty($analyse_result)) {
         self::set_job_status($job_id, mediamosa_job_server_db::JOB_STATUS_FINISHED, '1.000');
@@ -423,9 +414,6 @@ class mediamosa_job_server {
       else {
         self::set_job_status($job_id, mediamosa_job_server_db::JOB_STATUS_FAILED, '1.000', 'Empty result, analyse failed.');
       }
-
-      // Log it.
-      self::log_mediafile($mediafile_id_src, 'Starting new followup analyse job for job ID: @job_id.', array('@job_id' => $job_id));
 
       // Update job_server_analyse row.
       $fields = array(
@@ -458,6 +446,44 @@ class mediamosa_job_server {
         )
       );
     }
+  }
+
+  /**
+   * Analyse mediafile.
+   */
+  public static function analyse($mediafile_id, $job_id = NULL) {
+    $analyse_result = array();
+
+    $mediafile_path = mediamosa_storage::get_realpath_mediafile($mediafile_id);
+    $mime_type = mediamosa_mimetype::get_mime_type($mediafile_path);
+    $analyse_result[mediamosa_asset_mediafile_metadata::MIME_TYPE] = array(
+      'type' => mediamosa_asset_mediafile_metadata_property_db::TYPE_CHAR,
+      'value' => $mime_type,
+    );
+
+    // Based on the mime_type there might be a tool that can analyse.
+    // Call the mediamosa_tool_can_analyse hook.
+    foreach (module_implements('mediamosa_tool_can_analyse') as $module) {
+      if (module_invoke($module, 'mediamosa_tool_can_analyse', $mime_type)) {
+        $analyse_result += module_invoke($module, 'mediamosa_tool_analyse', $mediafile_id);
+      }
+    }
+
+    // Make an informative log entry.
+    $analyse_output = array();
+    foreach ($analyse_result as $key => $value) {
+      $analyse_output[] = $key . ' [' . $value['type'] . '] ' . $value['value'];
+    }
+    $link_asset = self::get_asset_link($job_id);
+    self::log_mediafile($mediafile_id, 'Job analyse (Job ID: @job_id) returned output: @output<br /><br />@link',
+      array(
+        '@job_id' => $job_id,
+        '@output' => implode("\n", $analyse_output) . "\n",
+        '@link' => $link_asset,
+      )
+    );
+
+    return $analyse_result;
   }
 
   /**

--- a/sites/all/modules/mediamosa_tool_ffmpeg/mediamosa_tool_ffmpeg.class.inc
+++ b/sites/all/modules/mediamosa_tool_ffmpeg/mediamosa_tool_ffmpeg.class.inc
@@ -21,6 +21,16 @@ class mediamosa_tool_ffmpeg {
    */
   const BLACK_STILL_INTERVAL = 30;
 
+  /**
+   * Returns TRUE when we support this mime-type.
+   *
+   * @param string $mime_type
+   *   mimetype request.
+   */
+  public static function is_supported($mime_type) {
+    return preg_match('#^(video|audio)\/.+#', $mime_type);
+  }
+
   // ---------------------------------------------------------------- Functions.
   /**
    * Calculate the aspect ratio.
@@ -426,4 +436,26 @@ class mediamosa_tool_ffmpeg {
     $execution_string .= ' > /dev/null &';
     return $execution_string;
   }
+
+  /**
+   * Calculate the bits per plane.
+   *
+   * @param int $width
+   *   width
+   * @param int $height
+   *   height
+   * @param int $fps
+   *   frames per second
+   * @param int $bitrate
+   *   bitrate
+   */
+  public static function calculate_bpp($width, $height, $fps, $bitrate) {
+    $result = '';
+    if ($width != '' && $height != '' && $fps != '' && $bitrate != '') {
+      $result = round((($bitrate * 1000) / ($fps * $width * $height)), 2);
+    }
+
+    return $result;
+  }
+
 }

--- a/sites/all/modules/mediamosa_tool_ffmpeg/mediamosa_tool_ffmpeg.module
+++ b/sites/all/modules/mediamosa_tool_ffmpeg/mediamosa_tool_ffmpeg.module
@@ -9,7 +9,7 @@
  */
 function mediamosa_tool_ffmpeg_permission() {
   return array(
-    'access mediamosa tool ffmpeg' =>  array(
+    'access mediamosa tool ffmpeg' => array(
       'title' => t('Access MediaMosa Tool module for FFmpeg toolset'),
       'description' => t('Enables the user to use the FFmpeg toolset.'),
     ),
@@ -18,21 +18,159 @@ function mediamosa_tool_ffmpeg_permission() {
 
 /**
  * Implements hook_mediamosa_tool_info().
- *
- * @return array
- *  An array filled with information about the tool.
  */
 function mediamosa_tool_ffmpeg_mediamosa_tool_info() {
-  return array(mediamosa_tool_ffmpeg::NAME => array(
-    'name' => t('ffmpeg'),
-    'description' => t('The ffmpeg tool for transcoding video files.'),
-  ));
+  return array(
+    mediamosa_tool_ffmpeg::NAME => array(
+      'name' => t('ffmpeg'),
+      'description' => t('The ffmpeg tool for transcoding video files.'),
+    ));
+}
+
+/**
+ * Implements hook_mediamosa_tool_can_analyse().
+ */
+function mediamosa_tool_ffmpeg_mediamosa_tool_can_analyse($mime_type) {
+  return mediamosa_tool_ffmpeg::is_supported($mime_type);
+}
+
+/**
+ * Implements hook_mediamosa_tool_analyse().
+ */
+function mediamosa_tool_ffmpeg_mediamosa_tool_analyse($mediafile_id) {
+
+  $execution_string = sprintf(
+    '%s %s %s',
+    mediamosa_settings::lua_analyse_script(),
+    mediamosa_storage::get_local_mediafile_path($mediafile_id),
+    $mediafile_id
+  );
+
+  mediamosa_watchdog::log_mediafile($mediafile_id, 'Start analyse: @command', array('@command' => $execution_string), NULL, WATCHDOG_NOTICE, 'tool ffmpeg');
+
+  // Return the result from the exec.
+  $analyse_result = mediamosa_io::exec($execution_string . ' 2>&1');
+
+  // Store parsed result.
+  $parsed_analyse_result = array();
+
+  // Walk through results and make an informative array.
+  // These are used in mediamosa_asset_mediafile_metadata::store_analyse().
+  foreach ($analyse_result as $line) {
+    if (strpos($line, ':') !== FALSE) {
+      list($name, $value) = explode(':', $line, 2);
+      if (trim($value) == '') {
+        // Dont store empty values.
+        continue;
+      }
+      switch ($name) {
+        case 'Video-codec':
+          $parsed_analyse_result[mediamosa_asset_mediafile_metadata::VIDEO_CODEC] = array(
+            'type' => mediamosa_asset_mediafile_metadata_property_db::TYPE_CHAR,
+            'value' => trim($value),
+          );
+          break;
+
+        case 'Video-colorspace':
+          $parsed_analyse_result[mediamosa_asset_mediafile_metadata::COLORSPACE] = array(
+            'type' => mediamosa_asset_mediafile_metadata_property_db::TYPE_CHAR,
+            'value' => trim($value),
+          );
+          break;
+
+        case 'Video-size':
+          list($width, $height) = isset($value) ? explode('x', trim($value)) : array(0, 0);
+          $parsed_analyse_result[mediamosa_asset_mediafile_metadata::WIDTH] = array(
+            'type' => mediamosa_asset_mediafile_metadata_property_db::TYPE_INT,
+            'value' => $width,
+          );
+          $parsed_analyse_result[mediamosa_asset_mediafile_metadata::HEIGHT] = array(
+            'type' => mediamosa_asset_mediafile_metadata_property_db::TYPE_INT,
+            'value' => $height,
+          );
+          break;
+
+        case 'Video-framespersecond':
+          $parsed_analyse_result[mediamosa_asset_mediafile_metadata::FPS] = array(
+            'type' => mediamosa_asset_mediafile_metadata_property_db::TYPE_CHAR,
+            'value' => trim($value),
+          );
+          break;
+
+        case 'Audio-codec':
+          $parsed_analyse_result[mediamosa_asset_mediafile_metadata::AUDIO_CODEC] = array(
+            'type' => mediamosa_asset_mediafile_metadata_property_db::TYPE_CHAR,
+            'value' => trim($value),
+          );
+          break;
+
+        case 'Audio-frequency':
+          $parsed_analyse_result[mediamosa_asset_mediafile_metadata::SAMPLE_RATE] = array(
+            'type' => mediamosa_asset_mediafile_metadata_property_db::TYPE_INT,
+            'value' => trim($value),
+          );
+          break;
+
+        case 'Audio-channels':
+          $parsed_analyse_result[mediamosa_asset_mediafile_metadata::CHANNELS] = array(
+            'type' => mediamosa_asset_mediafile_metadata_property_db::TYPE_CHAR,
+            'value' => trim($value),
+          );
+          break;
+
+        case 'File-duration':
+          $parsed_analyse_result[mediamosa_asset_mediafile_metadata::FILE_DURATION] = array(
+            'type' => mediamosa_asset_mediafile_metadata_property_db::TYPE_CHAR,
+            'value' => trim($value),
+          );
+          break;
+
+        case 'File-type':
+          $parsed_analyse_result[mediamosa_asset_mediafile_metadata::CONTAINER_TYPE] = array(
+            'type' => mediamosa_asset_mediafile_metadata_property_db::TYPE_CHAR,
+            'value' => trim($value),
+          );
+          break;
+
+        case 'File-bitrate':
+          $parsed_analyse_result[mediamosa_asset_mediafile_metadata::BITRATE] = array(
+            'type' => mediamosa_asset_mediafile_metadata_property_db::TYPE_INT,
+            'value' => trim($value),
+          );
+          break;
+
+        case 'Is-hinted':
+          $parsed_analyse_result[mediamosa_asset_mediafile_metadata::IS_HINTED] = array(
+            'type' => mediamosa_asset_mediafile_metadata_property_db::TYPE_CHAR,
+            'value' => strcasecmp($value, 'yes') == 0 ? 'TRUE' : 'FALSE',
+          );
+          break;
+
+        case 'Is-inserted-md':
+          $parsed_analyse_result[mediamosa_asset_mediafile_metadata::IS_INSERTED_MD] = array(
+            'type' => mediamosa_asset_mediafile_metadata_property_db::TYPE_CHAR,
+            'value' => strcasecmp($value, 'yes') == 0 ? 'TRUE' : 'FALSE',
+          );
+          break;
+      }
+    }
+  }
+
+  // BPP is a calculated field.
+  if (isset($width) && isset($height) && isset($fps) && isset($bitrate)) {
+    $bpp = (string) mediamosa_tool_ffmpeg::calculate_bpp($width, $height, $fps, $bitrate);
+    if (isset($bpp) and ($bpp != '')) {
+      $parsed_analyse_result[mediamosa_asset_mediafile_metadata::BPP] = array(
+        'type' => mediamosa_asset_mediafile_metadata_property_db::TYPE_CHAR,
+        'value' => $bpp,
+      );
+    }
+  }
+  return $parsed_analyse_result;
 }
 
 /**
  * Implements hook_mediamosa_tool_mapping().
- *
- * @return The mapping array.
  */
 function mediamosa_tool_ffmpeg_mediamosa_tool_mapping() {
   return mediamosa_tool_params::get_by_tool(mediamosa_tool_ffmpeg::NAME);
@@ -40,9 +178,6 @@ function mediamosa_tool_ffmpeg_mediamosa_tool_mapping() {
 
 /**
  * Implements hook_mediamosa_tool_param_checking().
- *
- * @return array
- *  The mapping array.
  */
 function mediamosa_tool_ffmpeg_mediamosa_tool_param_checking($nice_parameter, $value) {
   mediamosa_tool_params::check_mapping(mediamosa_tool_ffmpeg::NAME, $nice_parameter, $value);

--- a/sites/all/modules/mediamosa_tool_image/mediamosa_tool_image.module
+++ b/sites/all/modules/mediamosa_tool_image/mediamosa_tool_image.module
@@ -5,6 +5,19 @@
  */
 
 /**
+ * Implements hook_mediamosa_tool_info().
+ *
+ * Get information about the tool.
+ */
+function mediamosa_tool_image_mediamosa_tool_info() {
+  return array(
+    mediamosa_tool_image::NAME => array(
+      'name' => t('ImageMagick'),
+      'description' => t('Image files like JPG, PNG, TIFF.'),
+    ));
+}
+
+/**
  * Implements hook_mediamosa_tool_can_analyse().
  */
 function mediamosa_tool_image_mediamosa_tool_can_analyse($mime_type) {
@@ -14,9 +27,37 @@ function mediamosa_tool_image_mediamosa_tool_can_analyse($mime_type) {
 /**
  * Implements hook_mediamosa_tool_analyse().
  *
- * @param array $job_ext
+ * Currently only implements width/height.
  */
-function mediamosa_tool_image_mediamosa_tool_analyse($job_ext) {
+function mediamosa_tool_image_mediamosa_tool_analyse($mediafile_id) {
+
+  $mediafile_path = mediamosa_storage::get_realpath_mediafile($mediafile_id);
+  $execution_command = strtr('exiv2 @mediafile', array('@mediafile' => $mediafile_path));
+  mediamosa_watchdog::log_mediafile($mediafile_id, 'Start analyse: @command', array('@command' => $execution_command), NULL, WATCHDOG_NOTICE, 'tool image');
+  $output_array = mediamosa_io::exec($execution_command);
+
+  // Output of exiv2 is in the form of "property : value"
+  // for example "Image size      : 3414 x 5090"
+  foreach ($output_array as $value) {
+    if (strpos($value, 'Image size') !== FALSE) {
+      list($property, $size) = explode(':', $value);
+      list($width, $height) = explode('x', $size);
+    }
+  }
+  $analyse = array();
+  $analyse['width'] = array('type' => 'INT', 'value' => trim($width));
+  $analyse['height'] = array('type' => 'INT', 'value' => trim($height));
+
+  return $analyse;
+}
+
+/**
+ * Implements hook_mediamosa_tool_analyse_metadata().
+ *
+ * Used to be tool_analyse(). This will analyse the file for possible extra
+ * Asset metadata.
+ */
+function mediamosa_tool_image_mediamosa_tool_analyse_metadata($job_ext) {
   $command_type = 'mediamosa_tool_image';
   $tool_id = mediamosa_tool_image::NAME;
   $execution_command = 'exiv2 @mediafile_location';
@@ -60,18 +101,6 @@ function mediamosa_tool_image_mediamosa_tool_can_generate_still($mime_type) {
  */
 function mediamosa_tool_image_mediamosa_tool_get_generate_still_exec($jobserver_job_id, $mediafile_id_source) {
   return mediamosa_tool_image::get_generate_still_exec($jobserver_job_id, $mediafile_id_source);
-}
-
-/**
- * Implements hook_mediamosa_tool_info().
- *
- * Get information about the tool.
- */
-function mediamosa_tool_image_mediamosa_tool_info() {
-  return array(mediamosa_tool_image::NAME => array(
-    'name' => t('ImageMagic'),
-    'description' => t('Image files like JPG, PNG, TIFF.'),
-  ));
 }
 
 /**

--- a/sites/all/modules/mediamosa_tool_pdf/mediamosa_tool_pdf.module
+++ b/sites/all/modules/mediamosa_tool_pdf/mediamosa_tool_pdf.module
@@ -39,9 +39,39 @@ function mediamosa_tool_pdf_mediamosa_tool_can_analyse($mime_type) {
 /**
  * Implements hook_mediamosa_tool_analyse().
  *
- * @param array $job_ext
+ * Currently only implements number of pages.
  */
-function mediamosa_tool_pdf_mediamosa_tool_analyse($job_ext) {
+function mediamosa_tool_pdf_mediamosa_tool_analyse($mediafile_id) {
+
+  $mediafile_path = mediamosa_storage::get_realpath_mediafile($mediafile_id);
+  $execution_command = strtr('pdfinfo @mediafile', array('@mediafile' => $mediafile_path));
+  mediamosa_watchdog::log_mediafile($mediafile_id, 'Start analyse: @command', array('@command' => $execution_command), NULL, WATCHDOG_NOTICE, 'tool pdf');
+  $output_array = mediamosa_io::exec($execution_command);
+
+  // Output of pdfinfo is in the form of "property : value"
+  // for example "Pages:          3"
+  foreach ($output_array as $value) {
+    if (strpos($value, 'Pages:') !== FALSE) {
+      list($property, $pages) = explode(':', $value);
+    }
+    if (strpos($value, 'PDF version:') !== FALSE) {
+      list($property, $version) = explode(':', $value);
+    }
+  }
+  $analyse = array();
+  $analyse['pages'] = array('type' => 'INT', 'value' => trim($pages));
+  $analyse['PDF version'] = array('type' => 'CHAR', 'value' => trim($version));
+
+  return $analyse;
+}
+
+/**
+ * Implements hook_mediamosa_tool_analyse_metadata().
+ *
+ * Used to be tool_analyse(). This will analyse the file for possible extra
+ * Asset metadata.
+ */
+function mediamosa_tool_pdf_mediamosa_tool_analyse_metadata($job_ext) {
   $command_type = 'mediamosa_tool_pdf';
   $tool_id = mediamosa_tool_pdf::NAME;
   $execution_command = 'pdfinfo @mediafile_location';


### PR DESCRIPTION
Mediamosa_tools can implement a hook_can_analyse() based on mimetype and
a hook_analyse() to perform the actual analyse. These functions provide
technical metadata that are stored in mediafile metadata.
