### PR TITLE
{TICKET_URI} does not work when filename contains "special" characters

### DIFF
--- a/sites/all/modules/mediamosa/core/storage/mediamosa_storage.class.inc
+++ b/sites/all/modules/mediamosa/core/storage/mediamosa_storage.class.inc
@@ -734,8 +734,12 @@ abstract class mediamosa_storage {
    * @return string
    *   The path.
    */
-  public static function get_path_media_permanent_file($app_id, $mediafile_id = '', $filename = '') {
+  public static function get_path_media_permanent_file($app_id, $mediafile_id = '', $filename = '', $urlencode = false) {
+    if($urlencode) {
+      return $app_id . '/' . (!empty($mediafile_id) ? $mediafile_id[0] . '/' . $mediafile_id . '/' . rawurlencode($filename) : '');
+    } else {
     return $app_id . '/' . (!empty($mediafile_id) ? $mediafile_id[0] . '/' . $mediafile_id . '/' . $filename : '');
+    }
   }
 
   /**

--- a/sites/all/modules/mediamosa/lib/mediamosa_io.streamwrapper.local.class.inc
+++ b/sites/all/modules/mediamosa/lib/mediamosa_io.streamwrapper.local.class.inc
@@ -357,6 +357,9 @@ class mediamosa_io_streamwrapper_local extends mediamosa_io_streamwrapper {
     $server_uri = mediamosa_media::get_server_uri($mediafile_id, $uri, $response_type);
 
     // Rebuild uri with path.
+    if($is_public) {
+      $path = mediamosa_storage::get_path_media_permanent_file($app_id, $ticket_id, $filename, true);
+    }
     $server_uri_build = strtr($server_uri, array(mediamosa_media::PARAM_URI_TICKET => $path));
 
     // Return the information needed.


### PR DESCRIPTION
There is an issue playing mediafiles that have special characters in the filename ( ',",#, etc. ). If you directly use this uri in the object code there might be issues when a special character is present because this is not escaped and this breaks the uri or the javascript, depending on the character.

These changes make sure that the filename is urlencoded when in an url.