### PR TITLE
Change git:// to https:// for submodules to fix issues with http/https proxies

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "sites/all/modules/mediamosa_ck"]
 	path = sites/all/modules/mediamosa_ck
-	url = git://github.com/mediamosa/mediamosa-ck.git
+	url = https://github.com/mediamosa/mediamosa-ck.git
 [submodule "sites/all/modules/mediamosa_sdk"]
 	path = sites/all/modules/mediamosa_sdk
-	url = git://github.com/mediamosa/mediamosa-sdk.git
+	url = https://github.com/mediamosa/mediamosa-sdk.git


### PR DESCRIPTION
When using the http.proxy or https.proxy settings because you have to clone mediamosa via proxy, submodule updating will break due to the "git://" urls. This fixes that.
