### PR TITLE
Added allow header for video-js fonts.

### DIFF
--- a/mmplayer/video-js/font/.htaccess
+++ b/mmplayer/video-js/font/.htaccess
@@ -1,0 +1,5 @@
+<FilesMatch "\.(ttf|otf|eot|woff)$">
+  <IfModule mod_headers.c>
+    Header set Access-Control-Allow-Origin "*"
+  </IfModule>
+</FilesMatch>


### PR DESCRIPTION
The flash player in Firefox also needs a Access-Control-Allow-Origin in
order to access the fonts.
