### PR TITLE
Fixed function test that stopped registry rebuild.

### DIFF
--- a/sites/all/modules/mediamosa/mediamosa.module
+++ b/sites/all/modules/mediamosa/mediamosa.module
@@ -58,8 +58,11 @@ function mediamosa_stream_wrappers() {
 
   // Do not use our stream wrappers during update and at the point our stream
   // wrappers are not known.
-  if (defined('MAINTENANCE_MODE') && MAINTENANCE_MODE == 'update' && drupal_get_installed_schema_version('mediamosa', TRUE) < 7142) {
-    return $wrappers;
+  if (defined('MAINTENANCE_MODE') && (MAINTENANCE_MODE == 'update')) {
+    if ((function_exists('drupal_get_installed_schema_version'))
+      && drupal_get_installed_schema_version('mediamosa', TRUE) < 7142) {
+      return $wrappers;
+    }
   }
 
   // Our MediaMosa Stream Wrappers.


### PR DESCRIPTION
'drush rr' gave an error:

PHP Fatal error:  Call to undefined function drupal_get_installed_schema_version() in /var/www/mm/sites/all/modules/mediamosa/mediamosa.module on line 61
