### PR TITLE
Fixed -vf bug with non fitting size.

### DIFF
--- a/sites/all/modules/mediamosa/lib/mediamosa.lib.test
+++ b/sites/all/modules/mediamosa/lib/mediamosa.lib.test
@@ -261,7 +261,5 @@ class MediaMosaTypeValidation extends MediaMosaTestCase {
 
     // Validate.
     $this->check('command', mediamosa_sdk::TYPE_COMMAND, mediamosa_transcode_profile::arrayToCommand($commands));
-
-
   }
 }

--- a/sites/all/modules/mediamosa/mediamosa.settings.class.inc
+++ b/sites/all/modules/mediamosa/mediamosa.settings.class.inc
@@ -105,9 +105,7 @@ class mediamosa_settings {
   const MEDIA_CACHE_SECOND = 2592000;
 
   // FFmpeg.
-
-  const STILL_STRING = "' -s %s -padtop %d -padbottom %d -padleft %d -padright %d -vframes %d -an -deinterlace -y -ss %s -t %s -r %s -vcodec mjpeg -f image2'";
-  const STILL_STRING_VFPAD = "' -s %s -vf 'pad=%d:%d:%d:%d:black' -vframes %d -an -deinterlace -y -ss %s -t %s -r %s -vcodec mjpeg -f image2'";
+  const STILL_STRING_VFPAD = "' -s %s -vf 'yadif,scale=%s,pad=%d:%d:%d:%d:black' -vframes %d -an -y -ss %s -t %s -r %s -vcodec mjpeg -f image2'";
 
   const STILL_SCENE_STRING = 'ffmpeg -i %s -s %s -padtop %d -padbottom %d -padleft %d -padright %d -an -deinterlace -y -scene %s %s -r 1 -f image2 %s';
   const STILL_SCENE_STRING_VFPAD = 'ffmpeg -i %s -s %s -vf "pad=%d:%d:%d:%d:black" -an -deinterlace -y -scene %s %s -r 1 -f image2 %s';

--- a/sites/all/modules/mediamosa_tool_ffmpeg/mediamosa_tool_ffmpeg.class.inc
+++ b/sites/all/modules/mediamosa_tool_ffmpeg/mediamosa_tool_ffmpeg.class.inc
@@ -64,10 +64,12 @@ class mediamosa_tool_ffmpeg {
     return array(
       '-s' => $aspect_ratio['width'] . 'x' . $aspect_ratio['height'],
       '-vf' => strtr(
-        'pad=@width:@height:@v_padding:@h_padding:black',
+        'scale=@width:@height,pad=@width_plus:@height_plus:@v_padding:@h_padding:black',
         array(
-          '@width' => $aspect_ratio['width'] + ($aspect_ratio['v_padding'] * 2),
-          '@height' => $aspect_ratio['height'] + ($aspect_ratio['h_padding'] * 2),
+          '@width' => $aspect_ratio['width'],
+          '@width_plus' => $aspect_ratio['width'] + ($aspect_ratio['v_padding'] * 2),
+          '@height' => $aspect_ratio['height'],
+          '@height_plus' => $aspect_ratio['height'] + ($aspect_ratio['h_padding'] * 2),
           '@v_padding' => $aspect_ratio['v_padding'],
           '@h_padding' => $aspect_ratio['h_padding'],
         )
@@ -408,13 +410,33 @@ class mediamosa_tool_ffmpeg {
       ->condition(mediamosa_job_db::ID, $job_id)
       ->execute();
 
-    // Combine the string (only for linux, windows does not generate stills).
+    // Prepare with and heigt variations.
     $size_explode = explode('x', $size);
+    // -vf scale takes "width:height" as parameter:
+    $size_semicolon = $size_explode[0] . ':' . $size_explode[1];
     $size_width = ($v_padding > 0) ? $size_explode[0] + (2 * $v_padding) : 0;
     $size_height = ($h_padding > 0) ? $size_explode[1] + (2 * $h_padding) : 0;
 
-    $execution_string = sprintf('%s %s %s %s %s jpeg ' . mediamosa_settings::STILL_STRING_VFPAD, mediamosa_settings::lua_transcode_script(), mediamosa_storage::get_local_mediafile_path($mediafile_id_source), mediamosa_storage::get_realpath_temporary(), $mediafile_id_source, $job_id, $size, $size_width, $size_height, $v_padding, $h_padding,
-                        round($duration * $framerate), $frametime, $duration, 1);
+    // Create execution string.
+    // STILL_STRING_VFPAD = "' -s %s -vf
+    // 'yadif,scale=%s,pad=%d:%d:%d:%d:black' -vframes %d -an -y -ss %s -t %s
+    // -r %s -vcodec mjpeg -f image2'";
+    $execution_string = sprintf('%s %s %s %s %s jpeg ' . mediamosa_settings::STILL_STRING_VFPAD,
+                        mediamosa_settings::lua_transcode_script(),
+                        mediamosa_storage::get_local_mediafile_path($mediafile_id_source),
+                        mediamosa_storage::get_realpath_temporary(),
+                        $mediafile_id_source,
+                        $job_id,
+                        $size,
+                        $size_semicolon,
+                        $size_width,
+                        $size_height,
+                        $v_padding,
+                        $h_padding,
+                        round($duration * $framerate),
+                        $frametime,
+                        $duration,
+                        1);
     $execution_string .= ' > /dev/null &';
     return $execution_string;
   }

--- a/sites/all/modules/mediamosa_tool_ffmpeg/mediamosa_tool_ffmpeg.test
+++ b/sites/all/modules/mediamosa_tool_ffmpeg/mediamosa_tool_ffmpeg.test
@@ -47,65 +47,65 @@ class MediaMosaToolFfmpegTestCaseEga extends MediaMosaTestCaseEgaJob {
 
     // Basic aspect ratio test.
     $got = mediamosa_tool_ffmpeg::calcAspectRatio(1024, 576, '640x480');
-    $expecting = array('-s' => '640x360', '-vf' => "pad=640:480:0:60:black");
+    $expecting = array('-s' => '640x360', '-vf' => "scale=640:360,pad=640:480:0:60:black");
     $this->compare($expecting, $got);
 
     $got = mediamosa_tool_ffmpeg::calcAspectRatio(640, 480, '200x200');
-    $expecting = array('-s' => '200x152', '-vf' => "pad=200:200:0:24:black");
+    $expecting = array('-s' => '200x152', '-vf' => "scale=200:152,pad=200:200:0:24:black");
     $this->compare($expecting, $got);
 
     $got = mediamosa_tool_ffmpeg::calcAspectRatio(100, 100, '200x300');
-    $expecting = array('-s' => '200x200', '-vf' => "pad=200:300:0:50:black");
+    $expecting = array('-s' => '200x200', '-vf' => "scale=200:200,pad=200:300:0:50:black");
     $this->compare($expecting, $got);
 
     $got = mediamosa_tool_ffmpeg::calcAspectRatio(100, 100, '300x200');
-    $expecting = array('-s' => '200x200', '-vf' => "pad=300:200:50:0:black");
+    $expecting = array('-s' => '200x200', '-vf' => "scale=200:200,pad=300:200:50:0:black");
     $this->compare($expecting, $got);
 
     $got = mediamosa_tool_ffmpeg::calcAspectRatio(1920, 1080, '352x288');
-    $expecting = array('-s' => '352x198', '-vf' => "pad=352:286:0:44:black");
+    $expecting = array('-s' => '352x198', '-vf' => "scale=352:198,pad=352:286:0:44:black");
     $this->compare($expecting, $got);
 
     // With "padding = yes | no".
     //
     // Setting padding = yes.
     $got = mediamosa_tool_ffmpeg::calcAspectRatio(320, 176, '320x240', NULL, NULL, TRUE);
-    $expecting = array('-s' => '320x176', '-vf' => "pad=320:240:0:32:black");
+    $expecting = array('-s' => '320x176', '-vf' => "scale=320:176,pad=320:240:0:32:black");
     $this->compare($expecting, $got);
 
     // Setting padding = no.
     $got = mediamosa_tool_ffmpeg::calcAspectRatio(320, 176, '320x240', NULL, NULL, FALSE);
-    $expecting = array('-s' => '320x176', '-vf' => "pad=320:176:0:0:black");
+    $expecting = array('-s' => '320x176', '-vf' => "scale=320:176,pad=320:176:0:0:black");
     $this->compare($expecting, $got);
 
     // Setting padding = yes.
     $got = mediamosa_tool_ffmpeg::calcAspectRatio(320, 176, '640x480', NULL, NULL, TRUE);
-    $expecting = array('-s' => '640x352', '-vf' => "pad=640:480:0:64:black");
+    $expecting = array('-s' => '640x352', '-vf' => "scale=640:352,pad=640:480:0:64:black");
     $this->compare($expecting, $got);
 
     // Setting padding = no.
     $got = mediamosa_tool_ffmpeg::calcAspectRatio(320, 176, '640x480', NULL, NULL, FALSE);
-    $expecting = array('-s' => '640x352', '-vf' => "pad=640:352:0:0:black");
+    $expecting = array('-s' => '640x352', '-vf' => "scale=640:352,pad=640:352:0:0:black");
     $this->compare($expecting, $got);
 
     // Setting padding = yes.
     $got = mediamosa_tool_ffmpeg::calcAspectRatio(1280, 720, '352x288', NULL, NULL, TRUE);
-    $expecting = array('-s' => '352x200', '-vf' => "pad=352:288:0:44:black");
+    $expecting = array('-s' => '352x200', '-vf' => "scale=352:200,pad=352:288:0:44:black");
     $this->compare($expecting, $got);
 
     // Setting padding = no.
     $got = mediamosa_tool_ffmpeg::calcAspectRatio(1280, 720, '352x288', NULL, NULL, FALSE);
-    $expecting = array('-s' => '352x200', '-vf' => "pad=352:200:0:0:black");
+    $expecting = array('-s' => '352x200', '-vf' => "scale=352:200,pad=352:200:0:0:black");
     $this->compare($expecting, $got);
 
     // Setting padding = yes.
     $got = mediamosa_tool_ffmpeg::calcAspectRatio(720, 480, '1280x720', NULL, NULL, TRUE);
-    $expecting = array('-s' => '1080x720', '-vf' => "pad=1280:720:100:0:black");
+    $expecting = array('-s' => '1080x720', '-vf' => "scale=1080:720,pad=1280:720:100:0:black");
     $this->compare($expecting, $got);
 
     // Setting padding = no.
     $got = mediamosa_tool_ffmpeg::calcAspectRatio(720, 480, '1280x720', NULL, NULL, FALSE);
-    $expecting = array('-s' => '1080x720', '-vf' => "pad=1080:720:0:0:black");
+    $expecting = array('-s' => '1080x720', '-vf' => "scale=1080:720,pad=1080:720:0:0:black");
     $this->compare($expecting, $got);
 
     // Special cases.
@@ -120,7 +120,7 @@ class MediaMosaToolFfmpegTestCaseEga extends MediaMosaTestCaseEgaJob {
 
     // Without source size. Response is string = TRUE.
     $got = mediamosa_tool_ffmpeg::calcAspectRatio(0, 0, '1280x720', TRUE);
-    $expecting = array('-s' => '1280x720', '-vf' => "pad=1280:720:0:0:black");
+    $expecting = array('-s' => '1280x720', '-vf' => "scale=1280:720,pad=1280:720:0:0:black");
     $this->compare($expecting, $got);
   }
 }


### PR DESCRIPTION
Added a -vf scale filter in case of requesting an destination of smaller
size. Also added the -vf yadif filter to handle deinterlace (was
deprecated). Fixed for videos transcoding and image generation by
ffmpeg.
