### PR TITLE
Added use_filename_as_dctitle to upload restcall.

### DIFF
--- a/sites/all/modules/mediamosa/core/asset/mediafile/upload/mediamosa_asset_mediafile_upload.class.inc
+++ b/sites/all/modules/mediamosa/core/asset/mediafile/upload/mediamosa_asset_mediafile_upload.class.inc
@@ -132,7 +132,8 @@ class mediamosa_asset_mediafile_upload {
     $retranscode = FALSE,
     $completed_transcoding_url = '',
     $create_still = FALSE,
-    array $still_parameters = array()
+    array $still_parameters = array(),
+    $use_filename_as_dctitle = FALSE
   ) {
     // Set to false.
     $is_app_admin = FALSE;
@@ -225,6 +226,15 @@ class mediamosa_asset_mediafile_upload {
 
       // Update mediafile.
       mediamosa_asset_mediafile::update($app_id, $ticket[mediamosa_media_ticket_db::MEDIAFILE_ID], $ticket[mediamosa_media_ticket_db::OWNER_ID], $fields);
+
+      // Update asset:dc-title if requested.
+      if ($use_filename_as_dctitle) {
+        // Determine asset_id.
+        $mf = mediamosa_asset_mediafile::get($ticket[mediamosa_media_ticket_db::MEDIAFILE_ID], $app_id, array(mediamosa_asset_mediafile_db::ASSET_ID));
+        // Update metadata field.
+        $metadata_definitions_full = mediamosa_asset_metadata_property::get_metadata_properties_full();
+        mediamosa_asset_metadata::metadata_create($mf[mediamosa_asset_mediafile_db::ASSET_ID], $metadata_definitions_full, array('title' => array($filename)), 'append');
+      }
 
       // Update the job.
       mediamosa_job::update_progress_upload($job_id, $upload_file_info['size']);

--- a/sites/all/modules/mediamosa/modules/asset/mediafile/upload/mediamosa_asset_mediafile_upload.rest.class.inc
+++ b/sites/all/modules/mediamosa/modules/asset/mediafile/upload/mediamosa_asset_mediafile_upload.rest.class.inc
@@ -162,6 +162,7 @@ class mediamosa_rest_call_asset_mediafile_upload extends mediamosa_rest_call {
 
   const RETRANSCODE = 'retranscode';
   const FILENAME = 'filename';
+  const USE_FILENAME_AS_DCTITLE ='use_filename_as_dctitle';
   const COMPLETED_URL = 'completed_url';
   const COMPLETED_TRANSCODING_URL = 'completed_transcoding_url';
   const STILL_UPLOAD = 'still_upload';
@@ -324,6 +325,11 @@ class mediamosa_rest_call_asset_mediafile_upload extends mediamosa_rest_call {
           self::VAR_DESCRIPTION => 'The filename of the media file (PUT method only, ignored otherwise).',
           self::VAR_IS_REQUIRED => $this->is_method_put() ? self::VAR_IS_REQUIRED_YES : self::VAR_IS_REQUIRED_NO,
         ),
+        self::USE_FILENAME_AS_DCTITLE => array(
+          self::VAR_TYPE => mediamosa_sdk::TYPE_BOOL,
+          self::VAR_DESCRIPTION => 'After successful upload, set the dc.title of the asset as the filename of the upload.',
+          self::VAR_DEFAULT_VALUE => 'FALSE',
+        ),
         self::COMPLETED_URL => array(
           self::VAR_TYPE => mediamosa_sdk::TYPE_URL,
           self::VAR_DESCRIPTION => "This URL gives opportunity to the APP builder for a status raport; \nupload_ticket\nstatus_code\n\nThe upload_ticket is used to identify the upload. The status_code is a MediaMosa code.\nThe type is URL and not URI, because this parameter http:// or https://.",
@@ -391,6 +397,7 @@ class mediamosa_rest_call_asset_mediafile_upload extends mediamosa_rest_call {
       $tag = $this->get_param_value(self::TAG);
       $transcode_profiles = $this->get_param_value(self::TRANSCODE);
       $retranscode = $this->get_param_value(self::RETRANSCODE);
+      $use_filename_as_dctitle = $this->get_param_value(self::USE_FILENAME_AS_DCTITLE);
 
       // Is still upload?
       $still_upload = $this->get_param_value(self::STILL_UPLOAD);
@@ -422,7 +429,8 @@ class mediamosa_rest_call_asset_mediafile_upload extends mediamosa_rest_call {
           $retranscode,
           $completed_transcoding_url,
           $create_still,
-          $still_parameters
+          $still_parameters,
+          $use_filename_as_dctitle
         );
       }
     }

--- a/sites/all/modules/mediamosa/modules/asset/mediafile/upload/mediamosa_asset_mediafile_upload.test
+++ b/sites/all/modules/mediamosa/modules/asset/mediafile/upload/mediamosa_asset_mediafile_upload.test
@@ -29,6 +29,13 @@ class MediaMosaAssetMediafileUploadTestCaseEga extends MediaMosaTestCaseEga {
     // POST upload test.
     $this->uploadTestFile();
 
+    // POST upload test with filename = asset-title.
+    $result = $this->uploadTestFile(array('use_filename_as_dctitle' => 'TRUE'));
+
+    // Test if asset title equals filename.
+    $md = mediamosa_asset_metadata::metadata_get($result['asset_id']);
+    $this->assertTrue(mediamosa_io::basename($result['source_filename']) == $md['dublin_core']['title']['values'][0], 'Store filename as dc:title.');
+
     // PUT upload test.
     $this->uploadTestFile(array('use_put' => TRUE));
   }

--- a/sites/all/modules/mediamosa/simpletest/mediamosa.simpletest.ega.class.inc
+++ b/sites/all/modules/mediamosa/simpletest/mediamosa.simpletest.ega.class.inc
@@ -628,6 +628,7 @@ class MediaMosaTestCaseEga extends MediaMosaTestCase {
       'create_still' => FALSE,
       'transcode_inherits_acl' => FALSE,
       'transcode' => array(),
+      'use_filename_as_dctitle' => 'FALSE',
     );
 
     $source_filename = $options['filename'];
@@ -650,6 +651,7 @@ class MediaMosaTestCaseEga extends MediaMosaTestCase {
       'create_still' => $options['create_still'],
       'transcode_inherits_acl' => $options['transcode_inherits_acl'],
       'transcode' => $options['transcode'],
+      'use_filename_as_dctitle' => $options['use_filename_as_dctitle'],
     );
 
     // Upload the file.
@@ -714,6 +716,10 @@ class MediaMosaTestCaseEga extends MediaMosaTestCase {
     if (!empty($options['transcode'])) {
       // Set any transcode profiles.
       $parse_url['query']['transcode'] = $options['transcode'];
+    }
+
+    if ($options['use_filename_as_dctitle'] == 'TRUE') {
+      $parse_url['query']['use_filename_as_dctitle'] = $options['use_filename_as_dctitle'];
     }
 
     // Rebuild.


### PR DESCRIPTION
this optional parameter will after an successful upload, update the
asset dc:title field with the name of the filename. This is useful in
case of bulkuploads with forexample plupload.
