### PR TITLE
Removed deprecated waitFlush option in SOLR.

### DIFF
--- a/sites/all/modules/mediamosa_solr/3rdparty/SolrPhpClient/Apache/Solr/Service.php
+++ b/sites/all/modules/mediamosa_solr/3rdparty/SolrPhpClient/Apache/Solr/Service.php
@@ -824,7 +824,8 @@ class Apache_Solr_Service
 		$flushValue = $waitFlush ? 'true' : 'false';
 		$searcherValue = $waitSearcher ? 'true' : 'false';
 
-		$rawPost = '<commit expungeDeletes="' . $expungeValue . '" waitFlush="' . $flushValue . '" waitSearcher="' . $searcherValue . '" />';
+		//$rawPost = '<commit expungeDeletes="' . $expungeValue . '" waitFlush="' . $flushValue . '" waitSearcher="' . $searcherValue . '" />';
+                $rawPost = '<commit expungeDeletes="' . $expungeValue . '" waitSearcher="' . $searcherValue . '" />';
 
 		return $this->_sendRawPost($this->_updateUrl, $rawPost, $timeout);
 	}
@@ -1119,7 +1120,8 @@ class Apache_Solr_Service
 		$flushValue = $waitFlush ? 'true' : 'false';
 		$searcherValue = $waitSearcher ? 'true' : 'false';
 
-		$rawPost = '<optimize waitFlush="' . $flushValue . '" waitSearcher="' . $searcherValue . '" />';
+		//$rawPost = '<optimize waitFlush="' . $flushValue . '" waitSearcher="' . $searcherValue . '" />';
+                $rawPost = '<optimize waitSearcher="' . $searcherValue . '" />';
 
 		return $this->_sendRawPost($this->_updateUrl, $rawPost, $timeout);
 	}


### PR DESCRIPTION
This will enable Solr version 4 for MediaMosa.
