### PR TITLE
Added cql modifier 'keeporder'.

### DIFF
--- a/sites/all/modules/mediamosa/cql/mediamosa_cql.class.inc
+++ b/sites/all/modules/mediamosa/cql/mediamosa_cql.class.inc
@@ -114,6 +114,7 @@ abstract class mediamosa_cql {
 
   // Mediamosa specific.
   const BOOST = 'boost';
+  const KEEPORDER = 'keeporder';
 
   private $m_str_cql = FALSE;
   private $m_o_cql_part_group = FALSE;

--- a/sites/all/modules/mediamosa/cql/mediamosa_cql_part.class.inc
+++ b/sites/all/modules/mediamosa/cql/mediamosa_cql_part.class.inc
@@ -234,7 +234,7 @@ class mediamosa_cql_part_relation extends mediamosa_cql_modifiers {
    *   Returns TRUE when modifier is allowed, FALSE otherwise.
    */
   protected function mediamosa_cql_modifier_allowed_modifier($str) {
-    return in_array($str, array(mediamosa_cql::IGNORECASE, mediamosa_cql::RESPECTCASE, mediamosa_cql::STEM, mediamosa_cql::BOOST));
+    return in_array($str, array(mediamosa_cql::IGNORECASE, mediamosa_cql::RESPECTCASE, mediamosa_cql::STEM, mediamosa_cql::BOOST, mediamosa_cql::KEEPORDER));
   }
 
   /**

--- a/sites/all/modules/mediamosa_solr/mediamosa_solr.cql.class.inc
+++ b/sites/all/modules/mediamosa_solr/mediamosa_solr.cql.class.inc
@@ -279,11 +279,18 @@ class mediamosa_solr_asset_cql_context extends mediamosa_asset_cql_context {
           $str_search_term = mediamosa_unicode::strtolower($str_search_term);
         }
 
+        $keeporder = isset($relation_modifiers[mediamosa_cql::KEEPORDER]);
+
         // Split whitespace up into words.
         $words = preg_split('/\s+/', $str_search_term);
+        $keeporder_count = count($words);
+
         foreach ($words as $word) {
           if (trim($word) === '') {
             continue;
+          }
+          if ($keeporder) {
+            $boost = '^' . $keeporder_count--;
           }
 
           switch ($index2column[MEDIAMOSA_CQL_CONTEXT_KEY_TYPE]) {


### PR DESCRIPTION
SOLR normally orders by relevance. This modifier will try to maintain
the order as given with the field. This will work only in combination
with any (..). For example:

cql = asset_id any/keeporder (^lskdflsdkflskjd^ ^slkdfsdflsdfj^)
