### PR TITLE
Tomed done logging of NOT FOUND rest calls.

### DIFF
--- a/sites/all/modules/mediamosa/rest/mediamosa_rest.class.inc
+++ b/sites/all/modules/mediamosa/rest/mediamosa_rest.class.inc
@@ -359,11 +359,12 @@ class mediamosa_rest {
       }
 
       // Throw so mediamosa handles the output.
-      throw new mediamosa_exception_error(mediamosa_error::HTTP_NOT_FOUND, array(
-        '@uri' => print_r($uri, TRUE),
-        '@method' => ($method ? print_r($method, TRUE) : '-'),
-        '@params' => '-',
-      ));
+      throw new mediamosa_exception_error(mediamosa_error::HTTP_NOT_FOUND,
+        array(
+          '@uri' => print_r($uri, TRUE),
+          '@method' => ($method ? print_r($method, TRUE) : '-'),
+          '@params' => '-',
+        ), mediamosa_exception_error::MEDIAMOSA_EXCEPTION_SEVERITY_LOW);
     }
 
     // Add the matched uri to the response.


### PR DESCRIPTION
This will only show 'Page not found: admin/mediamosa (method: -,
parameters: -)' when mediamosa debug logging in on.
