### PR TITLE
Made /assets [GET] aware of trashcan and published

### DIFF
--- a/sites/all/modules/mediamosa/modules/asset/mediamosa_asset.publish.test
+++ b/sites/all/modules/mediamosa/modules/asset/mediamosa_asset.publish.test
@@ -82,6 +82,11 @@ class MediaMosaAssetPublishTestCaseEga extends MediaMosaTestCaseEga {
     $asset = $this->getAsset($asset_id_2);
     $this->assert($asset['asset']['published'] === 'FALSE', 'Is not published');
 
+    // Perform /assets [GET] tests.
+    $assets = $this->getAssets(array($asset_id_1, $asset_id_2, $asset_id_3));
+    $this->assert($assets['header']['item_count_total'] == '3', '/assets must return assets with and without published status.');
+
+    // Perform cql tests.
     $this->cql_do_search_test_assets_1('', array($asset_id_1 => TRUE));
     $this->cql_do_search_test_assets_1('', array($asset_id_2 => TRUE, $asset_id_3 => TRUE), array('published' => 'FALSE'));
 

--- a/sites/all/modules/mediamosa/modules/asset/mediamosa_asset.rest.class.inc
+++ b/sites/all/modules/mediamosa/modules/asset/mediamosa_asset.rest.class.inc
@@ -1349,6 +1349,7 @@ class mediamosa_rest_call_assets_get extends mediamosa_rest_call {
   const IS_OAI = 'is_oai';
   const VIEW_HIDDEN_METADATA = 'view_hidden_metadata';
   const COUNT_VIEW = 'count_view';
+  const TRASHCAN = 'trashcan';
 
   // Search engine specific.
   const RELATED = 'related';
@@ -1466,6 +1467,23 @@ class mediamosa_rest_call_assets_get extends mediamosa_rest_call {
       ),
     );
 
+    $app_ids = $this->get_param_value_app();
+    $app_id = reset($app_ids);
+
+    $trashcan_default = mediamosa_asset::METADATA_TRASHCAN_FALSE;
+    if ($app_id) {
+      $app = mediamosa_app::get_by_appid($app_id);
+      if (!empty($app)) {
+        $trashcan_default = $app[mediamosa_app_db::TRASHCAN_ASSET_SEARCH_DEFAULT];
+      }
+    }
+    $var_setup[self::VARS][self::TRASHCAN] = array(
+      self::VAR_TYPE => mediamosa_sdk::TYPE_STRING,
+      self::VAR_DESCRIPTION => "Include or skip assets in the trashcan. Assets that where put in the trashcan will not show up by default in the asset search. The value 'FALSE' will hide all assets that where stored in the trashcan. Supply 'TRUE' to search the trashcan, or supply 'ALL' to search on all assets, regardless of its in the trashcan. If you u want to use CQL, make sure you supply 'ALL' as value for 'trashcan' on the REST call besides CQL. Once you supply 'ALL', use in CQL asset.trashcan == \"^TRUE^\", asset.trashcan == \"^FALSE^\" or for both asset.trashcan = \"^TRUE^ ^FALSE^\".",
+      self::VAR_DEFAULT_VALUE => $trashcan_default,
+      self::VAR_ALLOWED_VALUES => array('TRUE', 'FALSE', 'ALL'),
+    );
+
     // Include default.
     return self::get_var_setup_default($var_setup);
   }
@@ -1516,6 +1534,9 @@ class mediamosa_rest_call_assets_get extends mediamosa_rest_call {
     // supply the granted flag.
     $granted = TRUE;
 
+    // Don't use hierarchy search, just return the asset id's as requested.
+    $GLOBALS['mediamosa_params']['asset_hierarchy_include_combined'] = 'IGNORE';
+
     // Now search.
     $asset_search = mediamosa_search::asset(array(
       'app_ids' => $app_ids,
@@ -1530,6 +1551,9 @@ class mediamosa_rest_call_assets_get extends mediamosa_rest_call {
       'coll_id' => array(),
 
       'fav_user_id' => NULL,
+
+      'published' => 'ALL',
+      'trashcan' => $this->get_param_value(self::TRASHCAN),
 
       'granted' => $granted,
       'is_public_list' => FALSE,

--- a/sites/all/modules/mediamosa/modules/asset/mediamosa_asset.trashcan.test
+++ b/sites/all/modules/mediamosa/modules/asset/mediamosa_asset.trashcan.test
@@ -79,6 +79,10 @@ class MediaMosaAssetTrashcanTestCaseEga extends MediaMosaTestCaseEga {
     $this->cql_do_search_test_assets_1('', array($asset_id_1 => TRUE, $asset_id_2 => TRUE, $asset_id_3 => TRUE, $asset_id_4 => TRUE, $asset_id_5 => TRUE), array('trashcan' => 'FALSE'));
     $this->cql_do_search_test_assets_1('', array($asset_id_1 => TRUE, $asset_id_2 => TRUE, $asset_id_3 => TRUE, $asset_id_4 => TRUE, $asset_id_5 => TRUE), array('trashcan' => 'ALL'));
 
+    // Perform /assets [GET] tests.
+    $assets = $this->getAssets(array($asset_id_1, $asset_id_2, $asset_id_3, $asset_id_4, $asset_id_5));
+    $this->assert($assets['header']['item_count_total'] == '5', '/assets must return assets without deleted items.');
+
     // Delete number 3.
     try {
       mediamosa_asset::must_exists($asset_id_3);
@@ -112,6 +116,10 @@ class MediaMosaAssetTrashcanTestCaseEga extends MediaMosaTestCaseEga {
     $this->cql_do_search_test_assets_1('', array($asset_id_1 => TRUE, $asset_id_2 => TRUE, $asset_id_4 => TRUE, $asset_id_5 => TRUE), array('trashcan' => 'FALSE'));
     $this->cql_do_search_test_assets_1('', array($asset_id_1 => TRUE, $asset_id_2 => TRUE, $asset_id_4 => TRUE, $asset_id_5 => TRUE), array('trashcan' => 'ALL'));
 
+    // Perform /assets [GET] test.
+    $assets = $this->getAssets(array($asset_id_1, $asset_id_2, $asset_id_3, $asset_id_4, $asset_id_5));
+    $this->assert($assets['header']['item_count_total'] == '4', '/assets must return assets without deleted items.');
+
     // Now delete with trashcan on.
     // Trashcan number 2.
     $this->deleteAsset($asset_id_4, array('delete' => 'cascade', 'trashcan' => 'TRUE'));
@@ -136,6 +144,20 @@ class MediaMosaAssetTrashcanTestCaseEga extends MediaMosaTestCaseEga {
     $this->cql_do_search_test_assets_1('', array($asset_id_1 => TRUE, $asset_id_2 => TRUE, $asset_id_5 => TRUE), array('trashcan' => 'FALSE'));
     $this->cql_do_search_test_assets_1('', array($asset_id_1 => TRUE, $asset_id_2 => TRUE, $asset_id_4 => TRUE, $asset_id_5 => TRUE), array('trashcan' => 'ALL'));
 
+    // Perform /assets [GET] test.
+    $assets = $this->getAssets(
+      array(
+        $asset_id_1, $asset_id_2, $asset_id_3, $asset_id_4, $asset_id_5,
+      )
+    );
+    $this->assert($assets['header']['item_count_total'] == '3', '/assets must return assets without deleted items.');
+    $assets = $this->getAssets(
+      array(
+        $asset_id_1, $asset_id_2, $asset_id_3, $asset_id_4, $asset_id_5,
+      ),
+      array('trashcan' => 'ALL')
+    );
+    $this->assert($assets['header']['item_count_total'] == '4', '/assets with trashcan parameter.');
 
     $app_id = $this->a_app[mediamosa_app_db::APP_ID];
     db_update(mediamosa_app_db::TABLE_NAME)

--- a/sites/all/modules/mediamosa/simpletest/mediamosa.simpletest.ega.class.inc
+++ b/sites/all/modules/mediamosa/simpletest/mediamosa.simpletest.ega.class.inc
@@ -1387,6 +1387,44 @@ class MediaMosaTestCaseEga extends MediaMosaTestCase {
   }
 
   /**
+   * Get assets.
+   *
+   * Based on the GET rest call /assets (GET).
+   */
+  protected function getAssets($asset_ids, array $parameters = array(), array $expected_result_ids = array(mediamosa_error::ERRORCODE_OKAY)) {
+    // Parameters asset.
+    $parameters += array(
+      mediamosa_rest_call_asset_get::IS_APP_ADMIN => 'false',
+      mediamosa_rest_call_asset_get::USER_ID => self::SIMPLETEST_USER_ID,
+      'asset_id' => (array) $asset_ids,
+    );
+
+    // Do Post call.
+    $response = $this->restCallGet('assets', $parameters, array(), $expected_result_ids);
+
+    // Check response.
+    $this->assertTrue(
+      in_array((string) $response['xml']->header->request_result_id, $expected_result_ids),
+      strtr(
+        "Get assets, got result @result (@result_description)",
+        array(
+          '@result' => (string) $response['xml']->header->request_result_id,
+          '@result_description' => (string) $response['xml']->header->request_result_description,
+        )
+      )
+    );
+
+    // Must be ok to return object.
+    if (!in_array(mediamosa_error::ERRORCODE_OKAY, $expected_result_ids)) {
+      return FALSE;
+    }
+
+    $assets = mediamosa_lib::responsexml2array($response['xml']);
+    return $assets;
+  }
+
+
+  /**
    * OpenAPI search.
    * Based on the GET call /openapi/search (GET)
    */


### PR DESCRIPTION
It will always return published and non published items. And introduced
new parameter 'trashcan' to allow returning of deleted asset id's.