### PR TITLE
Modified /assets to maintain asset ordering.

### DIFF
--- a/sites/all/modules/mediamosa/modules/asset/mediamosa_asset.rest.class.inc
+++ b/sites/all/modules/mediamosa/modules/asset/mediamosa_asset.rest.class.inc
@@ -1489,17 +1489,14 @@ class mediamosa_rest_call_assets_get extends mediamosa_rest_call {
         throw new mediamosa_exception_error(mediamosa_error::ERRORCODE_VALIDATE_FAILED, array('@param' => self::ASSET_ID, '@type' => mediamosa_sdk::TYPE_ASSET_ID));
       }
 
-      $cql[] = 'asset_id=="^' . mediamosa_sdk::escape_cql($asset_id) . '^"';
+      $cql[] = '^' . mediamosa_sdk::escape_cql($asset_id) . '^';
     }
 
     // Create the CQL.
-    $cql = implode(' OR ', $cql);
+    $cql = 'asset_id any/keeporder "' . implode(' ', $cql) . '"';
 
     // View hidden metadata.
     $view_hidden_metadata = $this->get_param_value(self::VIEW_HIDDEN_METADATA);
-
-    $tag = $this->get_param_value(self::TAG);
-    $is_oai = $this->get_param_value(self::IS_OAI);
 
     $acl_user_id = $this->get_param_value(self::ACL_USER_ID);
     $acl_group_id = $this->get_param_value(self::ACL_GROUP_ID);

--- a/sites/all/modules/mediamosa_solr/mediamosa_solr.info
+++ b/sites/all/modules/mediamosa_solr/mediamosa_solr.info
@@ -25,6 +25,7 @@ files[] = tests/mediamosa_solr.stemming.test
 files[] = tests/mediamosa_solr.asset.cql.ext.test
 files[] = tests/mediamosa_solr.asset.cql.test
 files[] = tests/mediamosa_solr.asset.search.empty.test
+files[] = tests/mediamosa_solr.asset.common.test
 files[] = tests/mediamosa_solr.asset.cql.mediafile.duration.test
 files[] = tests/mediamosa_solr.asset.cql.isprivate.test
 files[] = tests/mediamosa_solr.asset.cql.app.coll.test

--- a/sites/all/modules/mediamosa_solr/tests/mediamosa_solr.asset.common.test
+++ b/sites/all/modules/mediamosa_solr/tests/mediamosa_solr.asset.common.test
@@ -1,0 +1,133 @@
+<?php
+/**
+ * @file
+ * Solr version of MediaMosaAssetCQLTestCaseEga
+ */
+
+class MediaMosaSolrAssetTrashcanTestCaseEga extends MediaMosaAssetTestCaseEga {
+  // ------------------------------------------------------------------ Members.
+
+  // ---------------------------------------------------------------- Functions.
+  public static function getInfo() {
+
+    $info = parent::getInfo();
+    $info['name'] = 'SOLR - ' . $info['name'];
+    $info['group'] = 'MediaMosa Solr';
+    $info['automatic_run_disabled'] = module_exists('mediamosa_solr') ? FALSE : TRUE;
+
+    return $info;
+  }
+
+  /**
+   * Make sure SOLR is on.
+   */
+  public static function mediamosa_run_enabled() {
+    return module_exists('mediamosa_solr') ? TRUE : FALSE;
+  }
+
+  /**
+   * Implements setUp().
+   *
+   * Any changes; see other classes(!)
+   */
+  protected function setUp() {
+    // Get Solr url from parent install.
+    $mediamosa_solr_url = mediamosa_solr_apache_solr_service::mediamosaGetUrl();
+
+    // Run parent first so we are inside sandbox.
+    // Call parent::setUp and preserve arguments.
+    $args = func_get_args();
+
+    $args = array_unique(array_merge(array(
+      'mediamosa_solr',
+    ), $args));
+
+    // PHP 5.3 does not allow to use $this as we do here.
+    if (drupal_substr(phpversion(), 0, 3) < '5.3') {
+      call_user_func_array(array($this, 'parent::setUp'), $args);
+    }
+    else {
+      call_user_func_array('parent::setUp', $args);
+    }
+
+    // Solr set url.
+    variable_set('mediamosa_solr_url', $mediamosa_solr_url);
+
+    // Turn on Solr as search engine.
+    variable_set('mediamosa_search_engine', 'mediamosa_solr');
+  }
+
+  /**
+   * Implements tearDown().
+   *
+   * Any changes; see other classes(!)
+   */
+  protected function tearDown() {
+
+    $app_ids = array();
+    if (!empty($this->a_app['app_id'])) {
+      $app_ids[] = $this->a_app['app_id'];
+    }
+    if (!empty($this->a_app_2['app_id'])) {
+      $app_ids[] = $this->a_app_2['app_id'];
+    }
+    if (!empty($this->a_app_3['app_id'])) {
+      $app_ids[] = $this->a_app_3['app_id'];
+    }
+
+    // Teardown first (else teardown will sync assets sometimes to SOLR).
+    parent::tearDown();
+
+    // Remove it.
+    if (!empty($app_ids)) {
+      mediamosa_solr::delete_simpletest_documents($app_ids);
+    }
+  }
+
+  /**
+   * Can find "" around word(s).
+   *
+   * Solr does not index ".
+   */
+  public function engine_fulltext_can_find_with_quotes() {
+    return FALSE;
+  }
+
+  /**
+   * Indexes per word or per line?
+   *
+   * Text; master : m*r will match?
+   *       maste foor : m*r will match?
+   */
+  public function engine_fulltext_wildcard_indexes_lines() {
+    return TRUE;
+  }
+
+  /**
+   * Testing rest call get /assets
+   */
+  public function testAssets() {
+
+    // Create assets.
+    $asset_id = array();
+    $asset_id[1] = $this->createAsset();
+    $asset_id[2] = $this->createAsset();
+    $asset_id[3] = $this->createAsset();
+    $asset_id[4] = $this->createAsset();
+    $asset_id[5] = $this->createAsset();
+
+    // Perform /assets [GET] tests.
+    $assets = $this->getAssets(array($asset_id[1], $asset_id[2], $asset_id[3]));
+    $this->assert($assets['header']['item_count_total'] == '3', '/assets must return all assets requested.');
+    $this->assert($assets['items']['item'][0]['asset_id'] == $asset_id[1], '/assets must maintain ordering.');
+    $this->assert($assets['items']['item'][1]['asset_id'] == $asset_id[2], '/assets must maintain ordering.');
+    $this->assert($assets['items']['item'][2]['asset_id'] == $asset_id[3], '/assets must maintain ordering.');
+
+    // Test the ordering of assets given.
+    $assets = $this->getAssets(array($asset_id[3], $asset_id[2], $asset_id[1]));
+    $this->assert($assets['items']['item'][0]['asset_id'] == $asset_id[3], '/assets must maintain ordering.');
+    $this->assert($assets['items']['item'][1]['asset_id'] == $asset_id[2], '/assets must maintain ordering.');
+    $this->assert($assets['items']['item'][2]['asset_id'] == $asset_id[1], '/assets must maintain ordering.');
+  }
+
+}


### PR DESCRIPTION
Only works with solr atm due to cql: 'any/keeporder' use.