### PR TITLE
Change to support newer version of FFmpeg in vpx-transcode

### DIFF
--- a/sites/all/modules/mediamosa/lib/lua/vpx-transcode
+++ b/sites/all/modules/mediamosa/lib/lua/vpx-transcode
@@ -24,7 +24,8 @@ local RHOOK = lpeg.P("]") * space
 local digits = lpeg.R("09")^1
 local symbol = lpeg.R("az", "AZ") * lpeg.R("az", "AZ", "09", "__")^0
 
-local word = lpeg.C(symbol) * space
+local ffjunk = (space * (LPAREN * (1 - RPAREN)^0 * RPAREN))^0
+local word = lpeg.C(symbol) * space * ffjunk
 local number = lpeg.C(digits) * space
 local any_number = digits * space
 local float = lpeg.C(digits * "." * digits) * space
@@ -39,7 +40,6 @@ local aspectratio = lpeg.C(LHOOK * (1 - RHOOK)^0 * RHOOK) +
 local language = ((LPAREN * (1 - RPAREN)^0 * RPAREN) + (LHOOK * (1 - RHOOK)^0 * RHOOK))^0 * space
 local channels = ((number * space)^0 * word + float) * space
 local containertype = lpeg.C(lpeg.R("az", "AZ", "09", "__")^1)
-local ffjunk = (space * (LPAREN * (1 - RPAREN)^0 * RPAREN))^0
 -- local codec = (lpeg.C(symbol * (space * lpeg.P("(")^-1 * symbol * lpeg.P(")")^-1)^0) + hex) * space * ffjunk
 local codec = (lpeg.C(symbol)) * space * ffjunk
 local codecs = lpeg.Ct(codec * (SLASH * codec)^0)
@@ -105,6 +105,7 @@ end
 -- Stream #0.0(und): Video: h264 (High), yuv420p, 1280x720 [PAR 1:1 DAR 16:9], 744 kb/s, 29.94 fps, 29.92 tbr, 1k tbn, 59.83 tbc
 -- Stream #0.0: Video: mjpeg, yuvj422p, 640x480, 15 tbr, 15 tbn, 15 tbc
 -- Stream #0.0: Video: mjpeg (MJPG / 0x47504A4D), yuvj422p, 640x480, 15 tbr, 15 tbn, 15 tbc
+-- Stream #0:0(eng): Video: h264 (Main) (avc1 / 0x31637661), yuv420p(tv, bt709), 1920x1080, 9282 kb/s, 24 fps, 24 tbr, 2400 tbn, 4800 tbc (default)
 -- captures: stream, codecs, colorspace, size, ar, bitrate, tb (= fps)
 
 local ln_video = space * "Stream #" * steam_number * language * COLON *
@@ -116,7 +117,7 @@ local ln_video = space * "Stream #" * steam_number * language * COLON *
   (aspectratio + lpeg.Cc("unknown")) *
   (
     (COMMA * number * "kb/s")^-1 *
-    (COMMA * (lpeg.S("PDSF") * "AR" * space * any_number * ":" * any_number)^1)^-1 *
+    (COMMA * (lpeg.S("PDSF") * "AR" * space * any_number * ":" * any_number * space)^1)^-1 *
     ((COMMA * (float + number) * "fps")^-1 + lpeg.Cc("unknown"))
   ) *
   (COMMA * ((float + number) * unit) / convert_units) * space * "tbr"


### PR DESCRIPTION
This change includes fix to support newer version of FFmpeg (current version 2.6.x), which adds some additional information to output. I have provided sample of output.

There is also a fix for a bug, which should also appear in older versions (as there is space between "0:1 DAR").

** known issue  ** 2 pass encoding is not working due to change of some parameters .. working on a patch