### PR TITLE
Removed unwanted image style restriction.

### DIFF
--- a/sites/all/modules/mediamosa/core/asset/mediafile/still/mediamosa_asset_mediafile_still.class.inc
+++ b/sites/all/modules/mediamosa/core/asset/mediafile/still/mediamosa_asset_mediafile_still.class.inc
@@ -655,12 +655,6 @@ class mediamosa_asset_mediafile_still {
       throw new mediamosa_exception_error_mediafile_not_found(array('@mediafile_id' => $mediafile_id));
     }
 
-    // Get the style.
-    $still_style = mediamosa_asset_mediafile_still_style::get($style_id, $mediafile[mediamosa_asset_mediafile_db::APP_ID]);
-    if (!$still_style) {
-      throw new mediamosa_exception_error(mediamosa_error::ERRORCODE_CREATING_DERIVATIVE, array('@style' => $style_id, '@path' => mediamosa_io::realpath_safe($still_uri)));
-    }
-
     // The [mount_point]/data/still version does not have a extension (like the
     // original).
     $filename = mediamosa_media::filename_build($mediafile_id, '', $style_id);


### PR DESCRIPTION
Apps were unable to use other app's image-styles and global image
styles. This check is removed. So if for example image style
'mediamosa_sb_normal' is defined, all apps are able to use:
media/1/{letter}/{mediafile_id}/{mediafile_id},mediamosa_sb_normal.jpg