### PR TITLE
Rewritten PDF module.

### DIFF
--- a/sites/all/modules/mediamosa_tool_pdf/mediamosa_tool_pdf.class.inc
+++ b/sites/all/modules/mediamosa_tool_pdf/mediamosa_tool_pdf.class.inc
@@ -22,11 +22,6 @@ class mediamosa_tool_pdf {
   const MEDIAMOSA_TOOL_PDF_KEY_VALUE_SEPARATOR = ':';
 
   /**
-   * Warning level for pdf2swf.
-   */
-  const MEDIAMOSA_MAINTENANCE_STATUS_CONFIGURATION_PDF2SWF_WARNING = '0';
-
-  /**
    * Warning level for pdfinfo.
    */
   const MEDIAMOSA_MAINTENANCE_STATUS_CONFIGURATION_PDFINFO_WARNING = '0';
@@ -39,6 +34,57 @@ class mediamosa_tool_pdf {
    */
   public static function is_supported($mime_type) {
     return in_array($mime_type, array(self::MEDIAMOSA_TOOL_PDF_MIME_TYPE_PDF));
+  }
+
+  /**
+   * Generate still.
+   *
+   * @param string $jobserver_job_id
+   *   id of jobserver.
+   * @param string $mediafile_id_source
+   *   mediafile_id of source.
+   */
+  public static function get_generate_still_exec($jobserver_job_id, $mediafile_id_source) {
+
+    $job_server_still = mediamosa_job_server_still::get($jobserver_job_id);
+    $job_server = mediamosa_job_server::get($jobserver_job_id);
+    $job_id = $job_server[mediamosa_job_server_db::JOB_ID];
+
+    $parameter_string = array();
+    if ($job_server_still) {
+
+      // WxH.
+      $size = $job_server_still[mediamosa_job_server_still_db::SIZE];
+
+      // Resize. The resize is done separately as combining them in 1
+      // convert call produces black images.
+      if ($size != '') {
+        $resize_option = 'nice convert -resize ' . $size . ' @mediafile_dest @mediafile_dest;';
+      }
+
+      // Source.
+      $mediafile_source = mediamosa_storage::get_realpath_mediafile($mediafile_id_source);
+
+      // Dest.
+      $mediafile_dest = mediamosa_storage::get_realpath_temporary_file($job_id . '-001.jpeg');
+
+      $execute_string_options = array(
+        '@mediafile_dest' => $mediafile_dest,
+        // Add [0] for first page.
+        '@mediafile_source' => $mediafile_source . '[0]',
+        '@parameter_string' => implode(' ', $parameter_string),
+        '@status_file' => mediamosa_storage::get_realpath_status_file($job_id),
+        '@working_dir' => dirname($mediafile_dest),
+      );
+
+      // Execution string:
+      return strtr(
+        '{ echo "Errors: none"; echo "Status: done"; echo "Progress: 0.000"; echo "Warnings: none"; } > @status_file;' .
+        'export MAGICK_TMPDIR=@working_dir;nice convert @mediafile_source @parameter_string @mediafile_dest; ' .
+        $resize_option .
+        '{ echo "Errors: none"; echo "Status: done"; echo "Progress: 1.000"; echo "Warnings: none"; } > @status_file;',
+        $execute_string_options);
+    }
   }
 
   /**
@@ -66,7 +112,77 @@ class mediamosa_tool_pdf {
       // Build the execute_string.
       return strtr('mkdir @file_location; cd @file_location; pdf2swf @mediafile_location -o @mediafile_id @params; cp @mediafile_id ../@mediafile_id.swf; cd ..; rm -r @file_location; { echo "Errors: none"; echo "Status: done"; echo "Progress: 1.000"; echo "Warnings: none"; } > @status_file;', $execution_string_options);
     }
+    else {
+
+      $params = explode(' ', $options['parameter_string']);
+      $mf_ids = unserialize(urldecode($params[1]));
+      $files_to_pdf = array();
+      foreach (array_keys($mf_ids) as $mf_id) {
+        $files_to_pdf[] = mediamosa_storage::get_realpath_mediafile($mf_id);
+      }
+
+      $mfs = implode(' ', $files_to_pdf);
+
+      // Build the values.
+      $execution_string_options = array(
+        '@source_files' => $mfs,
+        '@mediafile_dest' => $options['location_dest_file'] . '.' . $options['file_extension'],
+        '@status_file' => $options['status_file'],
+      );
+
+      // Execution string.
+      // MAGICK_TEMPORY_PATH: use current dir for temp files instead
+      // of /tmp.
+      // -resize: only resize if image is > 8000pts.
+      $cmd = strtr(
+        '{ echo "Errors: none"; echo "Status: done"; echo "Progress: 0.000"; echo "Warnings: none"; } > @status_file;' .
+        'export MAGICK_TEMPORARY_PATH=.; nice convert -quality 95 @source_files -resize 8000x8000\> pdfa:@mediafile_dest; '
+        . '{ echo "Errors: none"; echo "Status: done"; echo "Progress: 1.000"; echo "Warnings: none"; } > @status_file;',
+        $execution_string_options);
+
+      return $cmd;
+    }
 
     return FALSE;
+  }
+
+  /**
+   * Implements hook_post_convert().
+   */
+  public static function post_convert($job_id, $mediafile_id_dest) {
+
+    // Get job info.
+    $job_info = mediamosa_job::get_job_ext($job_id);
+
+    $command = mediamosa_transcode_profile::commandToArray($job_info['command']);
+    $pdffilename = $command['pdffilename'];
+    $replace = $command['replace'];
+
+    // Make zipfilename safe.
+    $pdffilename = preg_replace("([^\w\s\d\-_~,;:\[\]\(\).])", '', $pdffilename);
+    $pdffilename = preg_replace("([\.]{2,})", '', $pdffilename);
+
+    // Get profile_id.
+    $transcode_profile = mediamosa_transcode_profile::get_by_machine_name('PDF');
+
+    mediamosa_db::db_update(mediamosa_asset_mediafile_db::TABLE_NAME)
+      ->fields(array(
+        mediamosa_asset_mediafile_db::IS_DOWNLOADABLE => mediamosa_asset_mediafile_db::IS_DOWNLOADABLE_TRUE,
+        mediamosa_asset_mediafile_db::FILENAME => isset($pdffilename) ? $pdffilename : 'pdf.pdf',
+        mediamosa_asset_mediafile_db::TRANSCODE_PROFILE_ID => $transcode_profile['transcode_profile_id'],
+        mediamosa_asset_mediafile_db::IS_ORIGINAL_FILE => mediamosa_asset_mediafile_db::IS_ORIGINAL_FILE_TRUE,
+      ))
+      ->condition(mediamosa_asset_mediafile_db::ID, $mediafile_id_dest)
+      ->execute();
+
+    // If replace == true, remove all other mediafiles with tool=pdf
+    // in this asset.
+    if ($replace) {
+      $mfs = mediamosa_asset_mediafile::get_by_asset_id($job_info['asset_id'], array(mediamosa_asset_mediafile_db::ID), array('tool' => self::NAME));
+
+      // Delete all mediafiles with tool pdf except mediafile_id_dest.
+      unset($mfs[$mediafile_id_dest]);
+      mediamosa_asset_mediafile::delete($mfs);
+    }
   }
 }

--- a/sites/all/modules/mediamosa_tool_pdf/mediamosa_tool_pdf.info
+++ b/sites/all/modules/mediamosa_tool_pdf/mediamosa_tool_pdf.info
@@ -13,3 +13,5 @@ dependencies[] = mediamosa_app
 
 ; Used files.
 files[] = mediamosa_tool_pdf.class.inc
+files[] = mediamosa_tool_pdf.rest.class.inc
+files[] = mediamosa_tool_pdf.test

--- a/sites/all/modules/mediamosa_tool_pdf/mediamosa_tool_pdf.install
+++ b/sites/all/modules/mediamosa_tool_pdf/mediamosa_tool_pdf.install
@@ -12,11 +12,13 @@ function mediamosa_tool_pdf_install() {
   $t = get_t();
   $default_params = array(
     array(
-      'pdf', 'def_viewer', '-b', NULL, NULL, NULL, '', 'FALSE', $t('Therefore the swf file will be "browseable", i.e. display some buttons for turning pages. The viewer swf to be used is determine'), 'CHECKBOX'),
+      'pdf', 'mediafiles', 'mediafiles', NULL, NULL, NULL, '', 'FALSE', $t('Array of mediafiles ids to add to the pdf.'), 'SELECT'),
     array(
-      'pdf', 'fonts', '-f', NULL, NULL, NULL, '', 'FALSE', $t("Store full fonts in SWF. (Don't reduce to used characters)."), 'CHECKBOX'),
+      'pdf', 'pdffilename', 'pdffilename', NULL, NULL, NULL, '', 'FALSE', $t('Name of the pdffile.'), 'SELECT'),
     array(
-      'pdf', 'flash_version', '-T', 8, 9, array(8, 9), 9, 'TRUE', $t('Set Flash Version in the SWF header to num.'), 'SELECT'),
+      'pdf', 'replace', 'replace', NULL, NULL, NULL, '', 'FALSE', $t('Remove any other existing generated pdf files by this tool in the asset.'), 'SELECT'),
+    array(
+      'pdf', 'max_width', 'max_width', NULL, NULL, NULL, '', 'FALSE', $t('Max width of PDF.'), 'SELECT'),
   );
 
   // Insert default mappings as nodes.
@@ -41,15 +43,11 @@ function mediamosa_tool_pdf_install() {
 
   $default_profiles = array(
     array(
-      'pdf to swf',
+      'PDF',
       'FALSE',
       'pdf',
-      'swf',
-      array(
-        'def_viewer' => mediamosa_tool_params_db::ALLOWED_VALUE_FOR_SWITCH,
-        'fonts' => mediamosa_tool_params_db::ALLOWED_VALUE_FOR_SWITCH,
-        'flash_version' => '9',
-      ),
+      'pdf',
+      array(),
     ),
   );
 
@@ -63,6 +61,7 @@ function mediamosa_tool_pdf_install() {
     $node->{mediamosa_transcode_profile_db::TOOL} = $default_profile[2];
     $node->{mediamosa_transcode_profile_db::FILE_EXTENSION} = $default_profile[3];
     $node->{mediamosa_transcode_profile_db::COMMAND} = mediamosa_transcode_profile::arrayToCommand($default_profile[4]);
+    $node->{mediamosa_transcode_profile_db::MACHINE_NAME} = mediamosa_db::generate_machine_name($default_profile[0], 'mediamosa_transcode_profile');
 
     $node = node_save($node);
   }
@@ -122,5 +121,78 @@ function mediamosa_tool_pdf_install() {
         $node = node_save($node);
       }
     }
+  }
+}
+
+/**
+ * Implements hook_unstall().
+ */
+function mediamosa_tool_pdf_uninstall() {
+
+  $query = new EntityFieldQuery();
+  $entities = $query
+    ->entityCondition('entity_type', 'node')
+    ->propertyCondition('type',
+      array(
+        mediamosa_node::MEDIAMOSA_NODE_TYPE_TRANSCODE_PROFILE,
+        mediamosa_node::MEDIAMOSA_NODE_TYPE_TOOL_MAPPING,
+        mediamosa_node::MEDIAMOSA_NODE_TYPE_TOOL_PARAMS,
+      ), 'IN')
+    ->execute();
+  $nodes = node_load_multiple(array_keys($entities['node']));
+
+  // Can't add tool=... to FieldQuery, so do it here.
+  $nodes_to_delete = array();
+  foreach ($nodes as $node) {
+    if ($node->tool == 'pdf') {
+      $nodes_to_delete[] = $node->nid;
+    }
+  }
+  node_delete_multiple($nodes_to_delete);
+}
+
+/**
+ * Added replace parameter to pdf tool.
+ */
+function mediamosa_tool_pdf_update_7000() {
+
+  $params = array(
+    array(
+      'pdf', 'replace', 'replace', NULL, NULL, NULL, '', 'FALSE', t('Remove any other existing generated pdf files by this tool in the asset.'), 'SELECT'),
+  );
+
+  // Insert default mappings as nodes.
+  foreach ($params as $param) {
+    $node = mediamosa_node::create_basic_node(mediamosa_node::MEDIAMOSA_NODE_TYPE_TOOL_PARAMS, $param[1]);
+
+    $node->{mediamosa_tool_params_db::TOOL} = $param[0];
+    $node->{mediamosa_tool_params_db::NICE_PARAMETER} = $param[1];
+    $node->{mediamosa_tool_params_db::TOOL_PARAMETER} = $param[2];
+    $node->{mediamosa_tool_params_db::MIN_VALUE} = $param[3];
+    $node->{mediamosa_tool_params_db::MAX_VALUE} = $param[4];
+    $node->{mediamosa_tool_params_db::ALLOWED_VALUE} = $param[5];
+    $node->{mediamosa_tool_params_db::DEFAULT_VALUE} = $param[6];
+    $node->{mediamosa_tool_params_db::REQUIRED} = $param[7];
+    $node->{mediamosa_tool_params_db::DESCRIPTION} = $param[8];
+    $node->{mediamosa_tool_params_db::TYPE_PARAMETER} = $param[9];
+
+    $node = node_save($node);
+  }
+}
+
+/**
+ * Added machine_name to pdf tool.
+ */
+function mediamosa_tool_pdf_update_7001() {
+
+  $result = mediamosa_db::db_query('SELECT nid FROM {mediamosa_transcode_profile} where tool=:tool', array(':tool' => mediamosa_tool_pdf::NAME));
+  foreach ($result as $record) {
+    $node = node_load($record['nid']);
+    if (isset($node->machine_name) && $node->machine_name !== '' && $node->machine_name !== NULL) {
+      continue;
+    }
+    $machine_name = empty($node->title) ? (empty($node->profile) ? 'mediamosa_transcode_profile' : $node->profile) : $node->title;
+    $node->machine_name = mediamosa_db::generate_machine_name($machine_name, 'mediamosa_transcode_profile');
+    node_save($node);
   }
 }

--- a/sites/all/modules/mediamosa_tool_pdf/mediamosa_tool_pdf.module
+++ b/sites/all/modules/mediamosa_tool_pdf/mediamosa_tool_pdf.module
@@ -34,8 +34,12 @@ function mediamosa_tool_pdf_mediamosa_tool_analyse($mediafile_id) {
     }
   }
   $analyse = array();
-  $analyse['pages'] = array('type' => 'INT', 'value' => trim($pages));
-  $analyse['PDF version'] = array('type' => 'CHAR', 'value' => trim($version));
+  if (isset($analyse['pages'])) {
+    $analyse['pages'] = array('type' => 'INT', 'value' => trim($pages));
+  }
+  if (isset($analyse['PDF version'])) {
+    $analyse['PDF version'] = array('type' => 'CHAR', 'value' => trim($version));
+  }
 
   return $analyse;
 }
@@ -55,6 +59,21 @@ function mediamosa_tool_pdf_mediamosa_tool_analyse_metadata($job_ext) {
 }
 
 /**
+ * Implements hook_mediamosa_tool_can_generate_still().
+ */
+function mediamosa_tool_pdf_mediamosa_tool_can_generate_still($mime_type) {
+  return mediamosa_tool_pdf::is_supported($mime_type);
+}
+
+/**
+ * Implements hook_mediamosa_tool_get_generate_still_exec().
+ */
+function mediamosa_tool_pdf_mediamosa_tool_get_generate_still_exec($jobserver_job_id, $mediafile_id_source) {
+  return mediamosa_tool_pdf::get_generate_still_exec($jobserver_job_id, $mediafile_id_source);
+}
+
+
+/**
  * Implements hook_mediamosa_tool_info().
  */
 function mediamosa_tool_pdf_mediamosa_tool_info() {
@@ -72,28 +91,10 @@ function mediamosa_tool_pdf_mediamosa_tool_info() {
 function _mediamosa_tool_pdf_status_generate() {
   // For several topics we provide a link to webpages with configuration hints.
   $helper_links = array(
-    'pdf2swf' => l(t('here'), 'http://mediamosa.org/trac/wiki/pdf2swf'),
     'pdfinfo' => l(t('here'), 'http://mediamosa.org/trac/wiki/pdfinfo'),
   );
 
   $results = array();
-
-  $exec_output = array();
-  $found = mediamosa_io::command_installed('pdf2swf -V', $exec_output);
-  $status_line = $found ? _mediamosa_maintenance_status_search_in_array('part of', $exec_output) : t('pdf2swf not found');
-  $version = $found ? drupal_substr($status_line, drupal_strlen('pdf2swf - part of swftools ')) : '';
-  $pos = strpos($version, '.');
-  if ($pos !== FALSE) {
-    $version = drupal_substr($version, 0, $pos);
-  }
-
-  $results['app_pdf2swf'] = array(
-    'title' => t('PDF tool: pdf2swf'),
-    'value' => $status_line,
-    'severity' => _mediamosa_maintenance_status_okerror($found && is_numeric($version) && $version >= mediamosa_tool_pdf::MEDIAMOSA_MAINTENANCE_STATUS_CONFIGURATION_PDF2SWF_WARNING),
-    'description' => $found ? '' : t('Install pdf2swf. You can find more information how to install pdf2swf !here', array('!here' => $helper_links['pdf2swf'])),
-  );
-
   $exec_output = array();
   $found = mediamosa_io::command_installed('pdfinfo -v', $exec_output, array(0, 99));
   $status_line = $found ? _mediamosa_maintenance_status_search_in_array('version', $exec_output) : t('pdfinfo not found');
@@ -113,7 +114,7 @@ function _mediamosa_tool_pdf_status_generate() {
   // Making the report.
   return array(
     'configuration' => array(
-      'title' => t('Image tool'),
+      'title' => t('PDF tool'),
       'results' => $results,
     ),
   );
@@ -134,4 +135,44 @@ function mediamosa_tool_pdf_mediamosa_status_collect($reset = FALSE) {
   }
 
   return $mediamosa_status_collect['statuses'];
+}
+
+/**
+ * Implements hook_mediamosa_register_rest_call().
+ */
+function mediamosa_tool_pdf_mediamosa_register_rest_call() {
+  $rest_calls = array();
+
+  // Rest call to create a pdf job.
+  $rest_calls['asset/$asset_id/pdf/create'][mediamosa_rest_call::METHOD_POST] = array(
+    mediamosa_rest_call::CLASS_NAME => 'mediamosa_rest_call_asset_pdf_create',
+    mediamosa_rest_call::STATUS => mediamosa_rest_call::STATUS_ACTIVE,
+    mediamosa_rest_call::MODULE_NAME => 'mediamosa_tool_pdf',
+    mediamosa_rest_call::VERSION => mediamosa_version::MEDIAMOSA_VERSION_3_6_0,
+  );
+
+  return $rest_calls;
+}
+
+/**
+ * Implements hook_mediamosa_register_rest_call_doc().
+ */
+function mediamosa_tool_pdf_mediamosa_register_rest_call_doc() {
+  $rest_calls = array();
+
+  $rest_calls['asset/$asset_id/pdf/create'][mediamosa_rest_call::METHOD_POST] = array(
+    mediamosa_rest_call::TITLE => 'Create PDF.',
+    mediamosa_rest_call::DESCRIPTION => 'Start a create PDF-job from the asset_ids given and store this in asset_id. Only one mediafile per asset is taken, use the profile_id to determine which one (by default the original is taken). The PDF is created from a series of images and plain text files.',
+    mediamosa_rest_call::EXAMPLE_REQUEST => '/asset/M9FyEFTVy0zFzpbOv7DaEH4U/pdf/create [POST]',
+    mediamosa_rest_call::RESPONSE_FIELDS => array(
+      'job_id' => 'Job id of the pdf job created.',
+    ),
+    mediamosa_rest_call::EXAMPLE_RESPONSE => '  <items>
+    <item>
+      <job_id>20621</job_id>
+      <asset_id>M9FyEFTVy0zFzpbOv7DaEH4U</asset_id>
+    </item>
+  </items>',
+  );
+  return $rest_calls;
 }

--- a/sites/all/modules/mediamosa_tool_pdf/mediamosa_tool_pdf.rest.class.inc
+++ b/sites/all/modules/mediamosa_tool_pdf/mediamosa_tool_pdf.rest.class.inc
@@ -1,0 +1,210 @@
+<?php
+/**
+ * @file
+ * Rest calls definition asset pdf.
+ */
+
+/**
+ * URI: /assets/$asset_id/pdf/create
+ * Method: POST
+ *
+ * Create a pdf file and store this as a mediafile in $asset_id.
+ */
+class mediamosa_rest_call_asset_pdf_create extends mediamosa_rest_call {
+  // ------------------------------------------------------------------ Consts.
+  // Rest vars;
+  const ASSET_ID = 'asset_id';
+  const ASSET_IDS = 'asset_ids';
+  const PROFILE = 'profile';
+  const FILENAME = 'filename';
+  const USER_ID = 'user_id';
+  const GROUP_ID = 'group_id';
+  const ACL_DOMAIN = 'acl_domain';
+  const ACL_REALM = 'acl_realm';
+  const IS_APP_ADMIN = 'is_app_admin';
+  const COMPLETED_TRANSCODING_URL = 'completed_transcoding_url';
+  const REPLACE = 'replace';
+
+  // ------------------------------------------------------------ Get Var Setup.
+  /**
+   * Implements get_var_setup().
+   */
+  public function get_var_setup() {
+    $var_setup = array();
+
+    $var_setup = array(
+      self::VARS => array(
+        self::ASSET_ID => array(
+          self::VAR_TYPE => mediamosa_sdk::TYPE_ASSET_ID,
+          self::VAR_DESCRIPTION => 'The asset ID to store the PDF.',
+          self::VAR_IS_REQUIRED => self::VAR_IS_REQUIRED_YES,
+        ),
+        self::ASSET_IDS => array(
+          self::VAR_TYPE => mediamosa_sdk::TYPE_ASSET_ID,
+          self::VAR_DESCRIPTION => 'The IDs of the assets to use.',
+          self::VAR_IS_REQUIRED => self::VAR_IS_REQUIRED_YES,
+          self::VAR_IS_ARRAY => self::VAR_IS_ARRAY_YES,
+        ),
+        self::USER_ID => array(
+          self::VAR_TYPE => mediamosa_sdk::TYPE_USER_ID,
+          self::VAR_IS_REQUIRED => self::VAR_IS_REQUIRED_YES,
+          self::VAR_DESCRIPTION => 'User id that performs request.',
+        ),
+        self::GROUP_ID => array(
+          self::VAR_TYPE => mediamosa_sdk::TYPE_GROUP_ID,
+          self::VAR_DESCRIPTION => 'The user group ID.',
+          self::VAR_RANGE_END => mediamosa_user_group_db::GROUP_ID_LENGTH,
+        ),
+        self::ACL_DOMAIN => array(
+          self::VAR_TYPE => mediamosa_sdk::TYPE_DOMAIN,
+          self::VAR_DESCRIPTION => 'Authentication domain parameter.',
+        ),
+        self::ACL_REALM => array(
+          self::VAR_TYPE => mediamosa_sdk::TYPE_REALM,
+          self::VAR_DESCRIPTION => 'Authentication realm parameter.',
+        ),
+        self::IS_APP_ADMIN => array(
+          self::VAR_TYPE => mediamosa_sdk::TYPE_BOOL,
+          self::VAR_DESCRIPTION => 'Admin has right to all assets.',
+          self::VAR_DEFAULT_VALUE => 'FALSE',
+        ),
+        self::PROFILE => array(
+          self::VAR_TYPE => mediamosa_sdk::TYPE_STRING,
+          self::VAR_DESCRIPTION => 'Selection of mediafiles, select specific transcode profile(s), default original.',
+          self::VAR_IS_REQUIRED => self::VAR_IS_REQUIRED_NO,
+          self::VAR_IS_ARRAY => self::VAR_IS_ARRAY_YES,
+          self::VAR_DEFAULT_VALUE => NULL,
+        ),
+        self::FILENAME => array(
+          self::VAR_TYPE => mediamosa_sdk::TYPE_STRING,
+          self::VAR_DESCRIPTION => 'Name of pdf filename, defaults to <asset_id>.pdf.',
+          self::VAR_IS_REQUIRED => self::VAR_IS_REQUIRED_NO,
+          self::VAR_DEFAULT_VALUE => NULL,
+        ),
+        self::COMPLETED_TRANSCODING_URL => array(
+          self::VAR_TYPE => mediamosa_sdk::TYPE_URL,
+          self::VAR_DESCRIPTION => 'Triggered when transcoding is completed.',
+          self::VAR_DEFAULT_VALUE => '',
+        ),
+        self::REPLACE => array(
+          self::VAR_TYPE => mediamosa_sdk::TYPE_BOOL,
+          self::VAR_DESCRIPTION => 'If true, will replace any previously generated pdfs in the asset.',
+          self::VAR_DEFAULT_VALUE => 'FALSE',
+        ),
+      ),
+    );
+
+    // Include default.
+    return self::get_var_setup_default($var_setup);
+  }
+
+  // ------------------------------------------------------------------ Do Call.
+  /**
+   * Implements do_call().
+   */
+  public function do_call() {
+    $mediamosa = mediamosa::get();
+
+    $app_ids = $this->get_param_value_app();
+    $app_id = reset($app_ids);
+    $is_app_admin = $this->get_param_value(self::IS_APP_ADMIN);
+
+    if (!(isset($app_id))) {
+      $app_id = 1;
+    }
+
+    $pdf_asset_id = $this->get_param_value(self::ASSET_ID);
+    $user_id = $this->get_param_value(self::USER_ID);
+    $group_id = $this->get_param_value(self::GROUP_ID);
+    $acl_domain = $this->get_param_value(self::ACL_DOMAIN);
+    $acl_realm = $this->get_param_value(self::ACL_REALM);
+    $completed_transcoding_url = $this->get_param_value(self::COMPLETED_TRANSCODING_URL);
+    $replace = $this->get_param_value(self::REPLACE);
+
+    // Test if asset id exists.
+    $asset = mediamosa_asset::must_exists($pdf_asset_id, NULL, TRUE);
+
+    // Owner check.
+    mediamosa_acl::owner_check($app_id, $user_id, $asset[mediamosa_asset_db::APP_ID], $asset[mediamosa_asset_db::OWNER_ID], $is_app_admin);
+
+    // Asset ids to use as source.
+    $asset_ids = $this->get_param_value(self::ASSET_IDS);
+    foreach ($asset_ids as $id) {
+      // Will fix some notices when we supply array in array.
+      if (is_array($id)) {
+        throw new mediamosa_exception_error(mediamosa_error::ERRORCODE_VALIDATE_FAILED, array('@param' => self::ASSET_IDS, '@type' => mediamosa_sdk::TYPE_ASSET_ID));
+      }
+    }
+
+    // What mediafiles to use.
+    $mf_profile_id = $this->get_param_value(self::PROFILE);
+
+    // Name of pdf.
+    $pdf_filename = $this->get_param_value(self::FILENAME);
+    if (!isset($pdf_filename) || trim($pdf_filename) == '') {
+      $pdf_filename = $pdf_asset_id;
+    }
+
+    // Insert a mediafile as this is required for transcode..
+    $mediafile_id = mediamosa_db::uuid($app_id);
+    mediamosa_asset_mediafile::create($mediafile_id, $app_id, $pdf_asset_id, $user_id,
+      array(mediamosa_asset_mediafile_db::IS_ORIGINAL_FILE => 'TRUE'));
+
+    // Collect the mediafile_id's to archive.
+    $mediafiles = array();
+    $options = array();
+    foreach ($asset_ids as $asset_id) {
+      if (((int) $mf_profile_id > 0) && ($mf_profile_id != 'original')) {
+        $options['transcode_profile_id'] = $mf_profile_id;
+      }
+      else {
+        $options['get_originals_only'] = TRUE;
+      }
+      $options['exclude_stills'] = TRUE;
+      $mediafile = mediamosa_asset_mediafile::get_by_asset_id($asset_id, array('mediafile_id', 'filename'), $options);
+      // We only use the first one.
+      $mediafile = reset($mediafile);
+
+      if (!isset($mediafile['mediafile_id'])) {
+        continue;
+      }
+      // Check access on the mediafile.
+      try {
+        mediamosa_acl::access_check_on_object(
+          mediamosa_acl::ACL_TYPE_MEDIAFILE,
+          $asset_id,
+          $mediafile['mediafile_id'],
+          $app_id,
+          $user_id,
+          $group_id,
+          $acl_domain,
+          $acl_realm,
+          $is_app_admin
+        );
+        $mediafiles[$mediafile['mediafile_id']] = $mediafile['filename'];
+      }
+      catch (mediamosa_exception_error_access_denied $e) {
+        // No access, just skip the mediafile.
+      }
+    }
+
+    if (count($asset_ids) > 0) {
+      $priority = 0;
+      $command = mediamosa_transcode_profile::arrayToCommand(
+        array(
+          'mediafiles' => urlencode(serialize($mediafiles)),
+          'pdffilename' => urlencode($pdf_filename),
+          'replace' => urlencode($replace),
+        )
+      );
+      $job_id = mediamosa_job::create_job_transcode($app_id, $user_id, $group_id, $is_app_admin, $mediafile_id, FALSE, array(), 'pdf', $command, 'pdf', NULL, $completed_transcoding_url, $priority, FALSE, $mediafile_id);
+
+      // Return the created job_id plus asset_id.
+      $mediamosa->add_item(array('job_id' => $job_id, 'asset_id' => $pdf_asset_id));
+    }
+    else {
+      // Default OK.
+      $mediamosa->set_result_okay();
+    }
+  }
+}

--- a/sites/all/modules/mediamosa_tool_pdf/mediamosa_tool_pdf.test
+++ b/sites/all/modules/mediamosa_tool_pdf/mediamosa_tool_pdf.test
@@ -1,0 +1,140 @@
+<?php
+/**
+ * @file
+ * Job tests for zip tool related functions.
+ */
+
+class MediaMosaToolPdfTestCaseEga extends MediaMosaTestCaseEgaJob {
+  /**
+   * Implements getInfo().
+   */
+  public static function getInfo() {
+    return array(
+      'name' => 'Tools - PDF',
+      'description' => 'Test the pdf tool.',
+      'group' => MEDIAMOSA_TEST_GROUP_MEDIAMOSA_CORE_TOOLS,
+      mediamosa_settings::MEDIAMOSA_RUN => mediamosa_settings::MEDIAMOSA_RUN_DAILY,
+    );
+  }
+
+  /**
+   * Implements setUp().
+   */
+  protected function setUp() {
+    parent::setUp('mediamosa_tool_pdf');
+  }
+
+  /**
+   * PDF REST call helper.
+   *
+   * @param string $asset_id
+   *   The asset to store the pdfs.
+   * @param array $asset_ids
+   *   The assets to add to pdfs.
+   * @param array $parameters
+   *   The REST call parameters.
+   * @param array $expected_result_ids
+   *   Expected result IDS.
+   *
+   * @return array
+   *   The rest response.
+   */
+  protected function AssetCreatePDF($asset_id, array $asset_ids, array $parameters = array(), array $expected_result_ids = array(mediamosa_error::ERRORCODE_OKAY)) {
+    // Parameters asset.
+    $parameters += array(
+      mediamosa_rest_call_asset_pdf_create::IS_APP_ADMIN => 'false',
+      mediamosa_rest_call_asset_pdf_create::USER_ID => self::SIMPLETEST_USER_ID,
+      mediamosa_rest_call_asset_pdf_create::FILENAME  => 'test.pdf',
+      mediamosa_rest_call_asset_pdf_create::ASSET_IDS  => $asset_ids,
+    );
+
+    // Required.
+    $uri = 'asset/' . $asset_id . '/pdf/create';
+
+    // Do Post call.
+    $response = $this->restCallPost($uri, $parameters, array(), $expected_result_ids);
+
+    // Check response.
+    $this->assertTrue(
+      in_array((string) $response['xml']->header->request_result_id, $expected_result_ids),
+      strtr(
+        "Create Pdf: @asset_ids, got result @result (@result_description)",
+        array(
+          '@asset_ids' => implode(', ', $asset_ids),
+          '@result' => (string) $response['xml']->header->request_result_id,
+          '@result_description' => (string) $response['xml']->header->request_result_description,
+        )
+      )
+    );
+
+    // Must be ok to return object.
+    if (!in_array(mediamosa_error::ERRORCODE_OKAY, $expected_result_ids)) {
+      return FALSE;
+    }
+
+    $response = mediamosa_lib::simplexml2array($response['xml']->items->item);
+
+    $this->var_export_verbose($response);
+    $this->assert(isset($response['job_id']) && $response['job_id'] > 0);
+    $this->assert(isset($response['asset_id']) && $response['asset_id'] !== '');
+
+    // Return data.
+    return $response;
+  }
+
+  /**
+   * Test download of 2 assets.
+   */
+  public function testPdfCreation() {
+
+    // Create asset to hold pdf.
+    $pdf_asset_id = $this->createAsset();
+
+    // Create 4 assets with an image.
+    $asset_ids = array();
+    for ($i = 1; $i < 5; $i++) {
+      $filename = drupal_get_path('module', 'mediamosa') . '/lib/testfiles/notblack-001.jpeg';
+      $upload = $this->uploadTestFile(array('filename' => $filename));
+      $asset_ids[$i] = $upload['asset_id'];
+      $mediafile_id = $upload['mediafile_id'];
+      $parameters = array('still_type' => 'NONE');
+      $this->createMediafileStill($mediafile_id, $parameters);
+    }
+    $this->doQueueCycleAll();
+
+    $this->AssetCreatePDF($pdf_asset_id, $asset_ids);
+
+    $this->doQueueCycleAll();
+
+    $asset = $this->getAsset($pdf_asset_id);
+    $this->var_export($asset);
+
+    $this->assert($asset['mediafiles']['mediafile']['metadata']['mime_type'] === 'application/pdf', 'Correct mime-type.');
+    $this->assert($asset['mediafiles']['mediafile']['metadata']['filesize'] > 0, 'PDF has a filesize.');
+    $this->assert($asset['mediafiles']['mediafile']['filename'] == 'test.pdf', 'PDF has correct filename.');
+    $filesize_4images = $asset['mediafiles']['mediafile']['metadata']['filesize'];
+
+    // Add extra image.
+    $upload = $this->uploadTestFile(array('filename' => $filename));
+    $asset_ids[5] = $upload['asset_id'];
+
+    // Test replace parameter TRUE.
+    $parameters = array(
+      mediamosa_rest_call_asset_pdf_create::REPLACE => 'TRUE',
+    );
+    $this->AssetCreatePDF($pdf_asset_id, $asset_ids, $parameters);
+    $this->doQueueCycleAll();
+    $asset = $this->getAsset($pdf_asset_id);
+    $this->var_export($asset['mediafiles']);
+    $this->assert($asset['mediafiles']['mediafile']['metadata']['filesize'] > $filesize_4images, 'PDF has increased in size.');
+
+    // Test replace parameter FALSE.
+    $parameters = array(
+      mediamosa_rest_call_asset_pdf_create::REPLACE => 'FALSE',
+    );
+    $this->AssetCreatePDF($pdf_asset_id, $asset_ids, $parameters);
+    $this->doQueueCycleAll();
+    $asset = $this->getAsset($pdf_asset_id);
+    $this->assert(count($asset['mediafiles']['mediafile']) == 2, 'The assets has 2 mediafiles.');
+  }
+}


### PR DESCRIPTION
The pdf tool was using the pdf2swf for viewing, and provided no creation
of pdf files. The new version does not provide a conversion for viewing
as the major browsers already have good support for that. Creating a pdf
from a number of images is now possible (/asset/id/pdf/create), as well
generating a still from a pdf.