### PR TITLE
Changed jobstart url: moved command to POST var.

### DIFF
--- a/sites/all/modules/mediamosa/core/job/scheduler/mediamosa_job_scheduler.class.inc
+++ b/sites/all/modules/mediamosa/core/job/scheduler/mediamosa_job_scheduler.class.inc
@@ -775,7 +775,6 @@ class mediamosa_job_scheduler {
       'mediafile_src' => $mediafile_id,
       'tool' => $job_parameters['tool'],
       'file_extension' => $job_parameters['file_extension'],
-      'command' => $job_parameters['command'],
     );
     $rest_url = 'server/jobstart?' . http_build_query($query_data);
 
@@ -783,7 +782,14 @@ class mediamosa_job_scheduler {
     self::log_mediafile($mediafile_id, 'Start job:' . $rest_url);
 
     // Do request.
-    $response = mediamosa_http::do_internal_call($uri, $rest_url, '', mediamosa_http::METHOD_POST);
+    $response = mediamosa_http::do_internal_call($uri, $rest_url,
+                http_build_query(array('command' => $job_parameters['command'])),
+                mediamosa_http::METHOD_POST,
+                array(
+                  'headers' => array(
+                    'Content-Type' => 'application/x-www-form-urlencoded',
+                  ),
+                ));
 
     if ($response->code == '201' || $response->code == '200') {
       try {


### PR DESCRIPTION
This way we make sure we dont get too long uri's resulting in 414's.