### PR TITLE
Removed dependency to dblog.

### DIFF
--- a/sites/all/modules/mediamosa/mediamosa.info
+++ b/sites/all/modules/mediamosa/mediamosa.info
@@ -12,7 +12,6 @@ dependencies[] = comment
 dependencies[] = color
 dependencies[] = help
 dependencies[] = menu
-dependencies[] = dblog
 dependencies[] = image
 dependencies[] = simpletest
 dependencies[] = mediamosa_sdk (>=3.6)


### PR DESCRIPTION
There is no need to force logging to dblog, when f.e. another logging
method like syslog is enabled.