### PR TITLE
Increase solr storage of val_int.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "sites/all/modules/mediamosa_ck"]
 	path = sites/all/modules/mediamosa_ck
-	url = https://github.com/mediamosa/mediamosa-ck.git
+	url = https://github.com/arjenk/mediamosa-ck.git
 [submodule "sites/all/modules/mediamosa_sdk"]
 	path = sites/all/modules/mediamosa_sdk
-	url = https://github.com/mediamosa/mediamosa-sdk.git
+	url = https://github.com/arjenk/mediamosa-sdk.git

--- a/sites/all/modules/mediamosa_solr/schema.xml
+++ b/sites/all/modules/mediamosa_solr/schema.xml
@@ -104,7 +104,7 @@
     <!--
       MediaMosa metadata types; (unsorted)
       -->
-    <fieldType name="val_int" class="solr.TrieIntField" precisionStep="8" omitNorms="true" positionIncrementGap="0"/>
+    <fieldType name="val_int" class="solr.TrieLongField" precisionStep="8" omitNorms="true" positionIncrementGap="0"/>
     <fieldType name="val_date" class="solr.TrieDateField" precisionStep="6" positionIncrementGap="0"/>
     <!-- A text field that only splits on whitespace for exact matching of words -->
     <!-- A general text field that has reasonable, generic
@@ -151,7 +151,7 @@
     <!--
       MediaMosa metadata types; (for sorting)
     -->
-    <fieldType name="sval_int" class="solr.SortableIntField" sortMissingLast="true" omitNorms="true"/>
+    <fieldType name="sval_int" class="solr.SortableLongField" sortMissingLast="true" omitNorms="true"/>
     <fieldType name="sval_date" class="solr.DateField" sortMissingLast="true" omitNorms="true"/>
     <fieldType name="sval_char" class="solr.StrField" sortMissingLast="true" omitNorms="true" />
 

--- a/sites/all/modules/mediamosa_solr/schema5.x-experimental.xml
+++ b/sites/all/modules/mediamosa_solr/schema5.x-experimental.xml
@@ -327,7 +327,7 @@
   <!--
     MediaMosa metadata types; (unsorted)
     -->
-  <fieldType name="val_int" class="solr.TrieIntField" precisionStep="8" omitNorms="true" positionIncrementGap="0"/>
+  <fieldType name="val_int" class="solr.TrieLongField" precisionStep="8" omitNorms="true" positionIncrementGap="0"/>
   <fieldType name="val_date" class="solr.TrieDateField" precisionStep="6" positionIncrementGap="0"/>
   <!-- A text field that only splits on whitespace for exact matching of words -->
   <!-- A general text field that has reasonable, generic
@@ -374,7 +374,7 @@
   <!--
     MediaMosa metadata types; (for sorting)
   -->
-  <fieldType name="sval_int" class="solr.TrieIntField" sortMissingLast="true" omitNorms="true"/>
+  <fieldType name="sval_int" class="solr.TrieLongField" sortMissingLast="true" omitNorms="true"/>
   <fieldType name="sval_date" class="solr.TrieDateField" precisionStep="0" positionIncrementGap="0"/>
   <fieldType name="sval_char" class="solr.StrField" sortMissingLast="true" omitNorms="true" />
 


### PR DESCRIPTION
In some cases the TrieIntField was not large enough for stored values in
val_int. Especially cases with filesize could reach the limit.