### PR TITLE
fixed [] operator not supported in php7.1

### DIFF
--- a/sites/all/modules/mediamosa/core/asset/mediafile/mediamosa_asset_mediafile.class.inc
+++ b/sites/all/modules/mediamosa/core/asset/mediafile/mediamosa_asset_mediafile.class.inc
@@ -661,7 +661,7 @@ class mediamosa_asset_mediafile {
       }
 
       // Default empty.
-      $items[$mediafile_id]['ega_stream_url'] = '';
+      $items[$mediafile_id]['ega_stream_url'] = [];
 
       // Stream URL, only if streamable.
       if (isset($items[$mediafile_id][$prefix . mediamosa_asset_mediafile_metadata::CONTAINER_TYPE]) && mediamosa_server::is_streamable($items[$mediafile_id][$prefix . mediamosa_asset_mediafile_metadata::CONTAINER_TYPE])) {


### PR DESCRIPTION
Attempting to view asset information in MediaMosa gave the following error:

> Error: [] operator not supported for strings in mediamosa_asset_mediafile::enrich_response_mediafile() (line 694 of /var/www/html/mediamosa/sites/all/modules/mediamosa/core/asset/mediafile/mediamosa_asset_mediafile.class.inc).

PHP version is 7.1.9.


