### PR TITLE
Select the first image in a multi-image file format such as tiff when…

### DIFF
--- a/sites/all/modules/mediamosa_tool_image/mediamosa_tool_image.class.inc
+++ b/sites/all/modules/mediamosa_tool_image/mediamosa_tool_image.class.inc
@@ -73,6 +73,10 @@ class mediamosa_tool_image {
       // Source.
       $mediafile_source = mediamosa_storage::get_realpath_mediafile($mediafile_id_source);
 
+      // Select the first image in a multi-image file format such as tiff. (mind the shell escaping for [])
+      // This is a nop for single-image file formats.
+      $mediafile_source .= '"[0]"';
+
       // Dest.
       $mediafile_dest = mediamosa_storage::get_realpath_temporary_file($job_info['job_id'] . sprintf(mediamosa_settings::STILL_EXTENSION, 1) . '.jpeg');
 


### PR DESCRIPTION
… generating a still.

Imagemagick convert will create dest-1.jpeg, dest-2.jpeg, ... when detecting multiple images in a tiff file. Since a single file "dest.jpeg" is expected still generation will fail. So by explicitly selecting the first image in yjr source we can be sure that there will always be a single "dest.jpeg". This works also in the case of a jpeg source where there is only one image possible for 1 file. (A noop)

There is also an added benefit. Some professional camera's add a lowres image to a tiff file with a corrupt exif directory. By selecting only the first highres image the "convert" command will not fail in this situation.